### PR TITLE
Fix Grok signed-in quota-unavailable state

### DIFF
--- a/electron/quota-state.js
+++ b/electron/quota-state.js
@@ -13,6 +13,7 @@ function quotaFingerprint(data) {
       model.id,
       model.ringPercent,
       model.quotaState,
+      model.authState,
       model.status,
       model.sessionUsedPercent,
       model.weeklyUsedPercent,
@@ -31,6 +32,7 @@ function keepLastKnown(previous, next, now = Date.now(), staleTtlMs = DEFAULT_ST
     models: next.models.map((model) => {
       const old = previousById[model.id];
       if (!old || model.quotaState === 'known') return { ...model, stale: false };
+      if (model.quotaState === 'expired' || model.authState === 'expired') return { ...model, stale: false };
       if (old.quotaState !== 'known' && !old.stale) return model;
       const observedAt = Date.parse(String(old.observedAt || ''));
       const ageMs = Number.isFinite(observedAt) ? Math.max(0, now - observedAt) : Number.POSITIVE_INFINITY;

--- a/electron/scrapers.js
+++ b/electron/scrapers.js
@@ -101,6 +101,7 @@ function detectedCard({
   provider,
   icon,
   quotaState,
+  authState = quotaState === 'known' ? 'signed_in' : quotaState === 'expired' ? 'expired' : 'unknown',
   sessionUsedPercent = null,
   weeklyUsedPercent = null,
   sessionResetText = 'Quota unknown',
@@ -115,6 +116,7 @@ function detectedCard({
     provider,
     icon,
     quotaState,
+    authState,
     quotaKnown: quotaState === 'known',
     sessionUsedPercent,
     weeklyUsedPercent,
@@ -1000,6 +1002,99 @@ function readGrokSession() {
   return null;
 }
 
+function parseGrokBillingConfig(config) {
+  let weeklyUsed = coercePercent(config && config.creditUsagePercent);
+  let sessionUsed = null;
+  const products = Array.isArray(config && config.productUsage) ? config.productUsage : [];
+  for (const product of products) {
+    const pct = coercePercent(product && (product.usagePercent ?? product.creditUsagePercent));
+    if (pct != null) {
+      sessionUsed = pct;
+      break;
+    }
+  }
+
+  if (weeklyUsed == null) {
+    const limit = config && config.monthlyLimit;
+    const spent = config && config.used;
+    const limitValue = limit && typeof limit === 'object'
+      ? Number(limit.val == null ? 0 : limit.val)
+      : null;
+    const spentValue = spent && typeof spent === 'object'
+      ? Number(spent.val == null ? 0 : spent.val)
+      : null;
+    if (Number.isFinite(limitValue) && limitValue > 0 && Number.isFinite(spentValue) && spentValue >= 0) {
+      weeklyUsed = Math.round(Math.min(100, (spentValue / limitValue) * 100));
+    }
+  }
+
+  return {
+    sessionUsed,
+    weeklyUsed,
+    weeklyReset: formatResetAt(config && config.currentPeriod && config.currentPeriod.end)
+      || formatResetAt(config && config.billingPeriodEnd)
+  };
+}
+
+function grokBillingCardFromResponse(res, name = 'Grok', provider = 'xAI') {
+  if (res && (res.status === 401 || res.status === 403)) {
+    return detectedCard({
+      id: 'grok',
+      name,
+      provider,
+      icon: 'grok',
+      quotaState: 'expired',
+      sessionResetText: 'Sign in: grok login',
+      weeklyResetText: 'OAuth token expired',
+      status: 'expired'
+    });
+  }
+
+  const config = res && res.json && res.json.config;
+  if (!res || res.status !== 200 || !config) {
+    return detectedCard({
+      id: 'grok',
+      name,
+      provider,
+      icon: 'grok',
+      quotaState: 'unknown',
+      authState: 'signed_in',
+      sessionResetText: 'Signed in · billing unavailable',
+      weeklyResetText: 'Quota unknown',
+      status: 'unknown'
+    });
+  }
+
+  const { sessionUsed, weeklyUsed, weeklyReset } = parseGrokBillingConfig(config);
+  if (weeklyUsed == null && sessionUsed == null) {
+    return detectedCard({
+      id: 'grok',
+      name,
+      provider,
+      icon: 'grok',
+      quotaState: 'unknown',
+      authState: 'signed_in',
+      sessionResetText: 'Signed in · usage unavailable',
+      weeklyResetText: weeklyReset || 'No percentage exposed',
+      status: 'unknown'
+    });
+  }
+
+  return detectedCard({
+    id: 'grok',
+    name,
+    provider,
+    icon: 'grok',
+    quotaState: 'known',
+    sessionUsedPercent: sessionUsed,
+    weeklyUsedPercent: weeklyUsed,
+    sessionLabel: 'Product usage',
+    weeklyLabel: 'Billing period',
+    sessionResetText: sessionUsed == null ? 'No session window' : 'Active',
+    weeklyResetText: weeklyReset || (weeklyUsed == null ? 'No weekly window' : 'Active')
+  });
+}
+
 async function getGrokUsage() {
   const grokDir = grokHome();
   if (!fs.existsSync(grokDir)) return null;
@@ -1033,71 +1128,7 @@ async function getGrokUsage() {
       },
       timeoutMs: 10000
     });
-    if (res.status === 401 || res.status === 403) {
-      return detectedCard({
-        id: 'grok',
-        name,
-        provider,
-        icon: 'grok',
-        quotaState: 'expired',
-        sessionResetText: 'Sign in: grok login',
-        weeklyResetText: 'OAuth token expired',
-        status: 'expired'
-      });
-    }
-    const config = res.json && res.json.config;
-    if (res.status !== 200 || !config) {
-      return detectedCard({
-        id: 'grok',
-        name,
-        provider,
-        icon: 'grok',
-        quotaState: 'unknown',
-        sessionResetText: 'Billing endpoint unavailable',
-        weeklyResetText: 'Quota unknown',
-        status: 'unknown'
-      });
-    }
-
-    const weekly = coercePercent(config.creditUsagePercent);
-    let sessionUsed = null;
-    const products = Array.isArray(config.productUsage) ? config.productUsage : [];
-    for (const product of products) {
-      const pct = coercePercent(product && (product.usagePercent ?? product.creditUsagePercent));
-      if (pct != null) {
-        sessionUsed = pct;
-        break;
-      }
-    }
-    const weeklyReset = formatResetAt(config.currentPeriod && config.currentPeriod.end)
-      || formatResetAt(config.billingPeriodEnd);
-
-    if (weekly == null && sessionUsed == null) {
-      return detectedCard({
-        id: 'grok',
-        name,
-        provider,
-        icon: 'grok',
-        quotaState: 'unknown',
-        sessionResetText: 'Usage data malformed',
-        weeklyResetText: 'Quota unknown',
-        status: 'unknown'
-      });
-    }
-
-    return detectedCard({
-      id: 'grok',
-      name,
-      provider,
-      icon: 'grok',
-      quotaState: 'known',
-      sessionUsedPercent: sessionUsed,
-      weeklyUsedPercent: weekly,
-      sessionLabel: 'Product usage',
-      weeklyLabel: 'Billing period',
-      sessionResetText: sessionUsed == null ? 'No session window' : 'Active',
-      weeklyResetText: weeklyReset || (weekly == null ? 'No weekly window' : 'Active')
-    });
+    return grokBillingCardFromResponse(res, name, provider);
   } catch (err) {
     return detectedCard({
       id: 'grok',
@@ -1105,7 +1136,8 @@ async function getGrokUsage() {
       provider,
       icon: 'grok',
       quotaState: 'unknown',
-      sessionResetText: 'Quota unknown',
+      authState: 'signed_in',
+      sessionResetText: 'Signed in · billing unavailable',
       weeklyResetText: 'Grok billing read failed',
       status: 'unknown'
     });
@@ -1371,7 +1403,10 @@ module.exports = {
   _test: {
     attachRing,
     coercePercent,
+    detectedCard,
+    grokBillingCardFromResponse,
     quotaStatus,
+    parseGrokBillingConfig,
     readWithCache,
     resetReaderCache: () => readerCache.clear()
   }

--- a/src/components/ModelPopoverCard.jsx
+++ b/src/components/ModelPopoverCard.jsx
@@ -11,7 +11,7 @@ function barColor(percent, state, stale, alertThreshold) {
   return '#10b981';
 }
 
-function QuotaRow({ label, percent, resetText, state, stale, alertThreshold }) {
+function QuotaRow({ label, percent, resetText, state, authState, stale, alertThreshold }) {
   const known = state === 'known' && percent != null;
   const color = barColor(percent, state, stale, alertThreshold);
   const width = known ? Math.min(100, percent) : 0;
@@ -34,7 +34,9 @@ function QuotaRow({ label, percent, resetText, state, stale, alertThreshold }) {
       </div>
       <div className="flex justify-between items-center mt-1 text-[11px] font-mono">
         <span style={{ color }} className="font-semibold">
-          {known ? `${stale ? '~' : ''}${percent}% Used` : state === 'expired' ? 'Sign in required' : 'Quota unknown'}
+          {known ? `${stale ? '~' : ''}${percent}% Used` :
+            state === 'expired' ? 'Sign in required' :
+              authState === 'signed_in' ? 'Signed in · usage unavailable' : 'Quota unknown'}
         </span>
         {known && (
           <span className="text-neutral-500">
@@ -77,6 +79,7 @@ export function ModelPopoverCard({ model, jobActivity }) {
         percent={model.sessionUsedPercent}
         resetText={model.sessionResetText}
         state={state}
+        authState={model.authState}
         stale={model.stale}
         alertThreshold={model.alertThreshold}
       />
@@ -85,6 +88,7 @@ export function ModelPopoverCard({ model, jobActivity }) {
         percent={model.weeklyUsedPercent}
         resetText={model.weeklyResetText}
         state={state}
+        authState={model.authState}
         stale={model.stale}
         alertThreshold={model.alertThreshold}
       />

--- a/tests/quota-state.test.js
+++ b/tests/quota-state.test.js
@@ -37,3 +37,20 @@ test('fresh known data clears stale state and affects fingerprints', () => {
   assert.equal(merged.models[0].stale, false);
   assert.notEqual(quotaFingerprint(known), quotaFingerprint(merged));
 });
+
+test('auth-only changes affect quota fingerprints', () => {
+  const unknown = { models: [{ id: 'grok', quotaState: 'unknown', authState: 'unknown' }] };
+  const signedIn = { models: [{ id: 'grok', quotaState: 'unknown', authState: 'signed_in' }] };
+  assert.notEqual(quotaFingerprint(unknown), quotaFingerprint(signedIn));
+});
+
+test('expired auth bypasses stale last-known quota', () => {
+  const expired = {
+    models: [{ id: 'codex', quotaState: 'expired', authState: 'expired', sessionResetText: 'Sign in' }]
+  };
+  const merged = keepLastKnown(known, expired, start + 60_000, 300_000);
+  assert.equal(merged.models[0].quotaState, 'expired');
+  assert.equal(merged.models[0].authState, 'expired');
+  assert.equal(merged.models[0].ringPercent, undefined);
+  assert.equal(merged.models[0].stale, false);
+});

--- a/tests/scrapers.test.js
+++ b/tests/scrapers.test.js
@@ -27,6 +27,83 @@ test('ring uses the highest available quota window', () => {
   assert.equal(result.status, 'warning');
 });
 
+test('Grok billing parser preserves legacy percentage fields', () => {
+  const result = _test.parseGrokBillingConfig({
+    creditUsagePercent: 42,
+    productUsage: [{ usagePercent: 17 }]
+  });
+  assert.equal(result.weeklyUsed, 42);
+  assert.equal(result.sessionUsed, 17);
+});
+
+test('Grok billing parser falls back to legacy included-credit totals', () => {
+  const result = _test.parseGrokBillingConfig({
+    monthlyLimit: { val: 80 },
+    used: { val: 20 }
+  });
+  assert.equal(result.weeklyUsed, 25);
+  assert.equal(result.sessionUsed, null);
+});
+
+test('Grok billing parser caps exhausted legacy usage at 100 percent', () => {
+  const result = _test.parseGrokBillingConfig({
+    monthlyLimit: { val: 80 },
+    used: { val: 120 }
+  });
+  assert.equal(result.weeklyUsed, 100);
+});
+
+test('Grok billing parser distinguishes a missing total from an encoded zero', () => {
+  const missing = _test.parseGrokBillingConfig({ monthlyLimit: { val: 80 } });
+  assert.equal(missing.weeklyUsed, null);
+
+  const zero = _test.parseGrokBillingConfig({ monthlyLimit: { val: 80 }, used: {} });
+  assert.equal(zero.weeklyUsed, 0);
+});
+
+test('Grok billing parser does not treat on-demand spend as included quota', () => {
+  const result = _test.parseGrokBillingConfig({
+    onDemandCap: { val: 80 },
+    onDemandUsed: { val: 20 }
+  });
+  assert.equal(result.weeklyUsed, null);
+  assert.equal(result.sessionUsed, null);
+});
+
+test('signed-in providers can report unavailable quota without becoming expired', () => {
+  const result = _test.detectedCard({
+    id: 'grok',
+    name: 'Grok',
+    provider: 'xAI',
+    icon: 'grok',
+    quotaState: 'unknown',
+    authState: 'signed_in'
+  });
+  assert.equal(result.quotaState, 'unknown');
+  assert.equal(result.authState, 'signed_in');
+  assert.equal(result.ringPercent, null);
+});
+
+test('Grok billing response separates expired auth from provider failures', () => {
+  const expired = _test.grokBillingCardFromResponse({ status: 401, json: {} });
+  assert.equal(expired.quotaState, 'expired');
+  assert.equal(expired.authState, 'expired');
+
+  const unavailable = _test.grokBillingCardFromResponse({ status: 500, json: {} });
+  assert.equal(unavailable.quotaState, 'unknown');
+  assert.equal(unavailable.authState, 'signed_in');
+});
+
+test('Grok accepted response stays signed in when percentage is not exposed', () => {
+  const result = _test.grokBillingCardFromResponse({
+    status: 200,
+    json: { config: { currentPeriod: { end: '2099-01-01T00:00:00Z' } } }
+  });
+  assert.equal(result.quotaState, 'unknown');
+  assert.equal(result.authState, 'signed_in');
+  assert.equal(result.ringPercent, null);
+});
+
 test('reader polling is single-flight and cached', async () => {
   let calls = 0;
   const entry = {


### PR DESCRIPTION
## Summary

- separate Grok authentication state from quota availability
- render valid sessions without a supported percentage as `Signed in · usage unavailable`
- use documented included-quota fields only and keep on-demand spend separate
- prevent stale cached quota from masking an expired session
- include authentication state in quota-state fingerprints

## Verification

- `npm test` — 28/28 passing
- `npm run smoke:logic` — passing
- `npm run build` — passing
- sanitized live scraper check: `authState=signed_in`, `quotaState=unknown`, `ringPercent=null`, status `Signed in · usage unavailable`

Fixes #4