### PR TITLE
Persist safe last-known quota readings across restarts

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -6,6 +6,7 @@ const { getAllInstalledAgentUsage, getLocalConfig, saveLocalConfig, probeCli, su
 const { readJobActivity } = require('./handoff_status');
 const { runtimePath, ensureRuntimeDir, writePid, clearPid } = require('./runtime-state');
 const { activityFingerprint, quotaFingerprint, keepLastKnown } = require('./quota-state');
+const { PERSISTED_QUOTA_TTL_MS, readQuotaCache, writeQuotaCache } = require('./quota-cache');
 
 let mainWindow = null;
 let tray = null;
@@ -16,6 +17,7 @@ let usageRefreshPromise = null;
 let overlayMode = 'dock';
 let overlayAnimation = null;
 const logFile = runtimePath('electron_boot.log');
+const quotaCacheFile = runtimePath('quota-cache.json');
 
 const OVERLAY = {
   dock: { width: 360, height: 620 },
@@ -181,10 +183,11 @@ async function refreshUsageData({ force = false } = {}) {
   usageRefreshPromise = (async () => {
     try {
       const liveData = attachActivity(await getAllInstalledAgentUsage({ force }));
-      const merged = keepLastKnown(cachedQuotaState, liveData);
+      const merged = keepLastKnown(cachedQuotaState, liveData, Date.now(), PERSISTED_QUOTA_TTL_MS);
       merged.jobActivity = liveData.jobActivity;
       merged.handoff = liveData.handoff;
       merged.reduceMotion = liveData.reduceMotion;
+      writeQuotaCache(quotaCacheFile, merged);
       if (cachedQuotaState && quotaFingerprint(cachedQuotaState) === quotaFingerprint(merged)) {
         cachedQuotaState = { ...merged, lastUpdated: liveData.lastUpdated };
         scheduleJobPoll(merged.jobActivity);
@@ -393,6 +396,14 @@ async function runCaptureIfRequested() {
 if (gotTheLock) app.whenReady().then(() => {
   try {
     ensureRuntimeDir();
+    const persisted = readQuotaCache(quotaCacheFile);
+    if (persisted) {
+      cachedQuotaState = {
+        ...persisted,
+        config: getLocalConfig(),
+        reduceMotion: reduceMotionEnabled(getLocalConfig())
+      };
+    }
     fs.appendFileSync(logFile, `[boot] pid=${process.pid} capture=${process.env.NOTCH_CAPTURE || ''}\n`);
     writePid(process.pid);
   } catch (err) {

--- a/electron/quota-cache.js
+++ b/electron/quota-cache.js
@@ -1,0 +1,131 @@
+const fs = require('fs');
+const path = require('path');
+
+const CACHE_VERSION = 1;
+const MAX_CACHE_BYTES = 64 * 1024;
+const PERSISTED_QUOTA_TTL_MS = 24 * 60 * 60 * 1000;
+
+const STRING_FIELDS = [
+  'id',
+  'name',
+  'provider',
+  'icon',
+  'authState',
+  'status',
+  'sessionLabel',
+  'weeklyLabel',
+  'sessionResetText',
+  'weeklyResetText',
+  'observedAt'
+];
+const PERCENT_FIELDS = [
+  'ringPercent',
+  'sessionUsedPercent',
+  'weeklyUsedPercent',
+  'alertThreshold'
+];
+
+function safeString(value, maxLength = 240) {
+  return typeof value === 'string' && value.length <= maxLength ? value : undefined;
+}
+
+function safePercent(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+function sanitizeKnownModel(model) {
+  if (!model || model.quotaState !== 'known') return null;
+  const id = safeString(model.id, 100);
+  const observedAt = safeString(model.observedAt, 64);
+  if (!id || !observedAt || !Number.isFinite(Date.parse(observedAt))) return null;
+
+  const safe = { id, quotaState: 'known', observedAt };
+  for (const field of STRING_FIELDS) {
+    if (field === 'id' || field === 'observedAt') continue;
+    const value = safeString(model[field]);
+    if (value !== undefined) safe[field] = value;
+  }
+  for (const field of PERCENT_FIELDS) {
+    const value = safePercent(model[field]);
+    if (value !== undefined) safe[field] = value;
+  }
+  if (safe.ringPercent === undefined
+      && safe.sessionUsedPercent === undefined
+      && safe.weeklyUsedPercent === undefined) return null;
+  return safe;
+}
+
+function createQuotaSnapshot(data, now = Date.now()) {
+  if (!data || !Array.isArray(data.models)) return null;
+  const models = data.models.map(sanitizeKnownModel).filter(Boolean);
+  if (!models.length) return null;
+  return {
+    version: CACHE_VERSION,
+    savedAt: new Date(now).toISOString(),
+    models
+  };
+}
+
+function parseQuotaSnapshot(value, now = Date.now(), ttlMs = PERSISTED_QUOTA_TTL_MS) {
+  if (!value || value.version !== CACHE_VERSION || !Array.isArray(value.models)) return null;
+  const models = value.models
+    .map(sanitizeKnownModel)
+    .filter(Boolean)
+    .filter((model) => {
+      const observedAt = Date.parse(model.observedAt);
+      return observedAt <= now + 60_000 && now - observedAt <= ttlMs;
+    })
+    .map((model) => ({
+      ...model,
+      stale: true,
+      staleAgeMs: Math.max(0, now - Date.parse(model.observedAt)),
+      lastError: 'Waiting for a fresh quota reading'
+    }));
+  if (!models.length) return null;
+  return {
+    models,
+    lastUpdated: safeString(value.savedAt, 64) || null
+  };
+}
+
+function readQuotaCache(filePath, now = Date.now(), ttlMs = PERSISTED_QUOTA_TTL_MS) {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_CACHE_BYTES) return null;
+    return parseQuotaSnapshot(JSON.parse(fs.readFileSync(filePath, 'utf8')), now, ttlMs);
+  } catch (err) {
+    return null;
+  }
+}
+
+function writeQuotaCache(filePath, data, now = Date.now()) {
+  const snapshot = createQuotaSnapshot(data, now);
+  if (!snapshot) return false;
+  const dir = path.dirname(filePath);
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(tempPath, `${JSON.stringify(snapshot)}\n`, { encoding: 'utf8', mode: 0o600 });
+    try {
+      fs.renameSync(tempPath, filePath);
+    } catch (err) {
+      fs.copyFileSync(tempPath, filePath);
+      fs.unlinkSync(tempPath);
+    }
+    return true;
+  } catch (err) {
+    try { fs.unlinkSync(tempPath); } catch (cleanupErr) {}
+    return false;
+  }
+}
+
+module.exports = {
+  CACHE_VERSION,
+  PERSISTED_QUOTA_TTL_MS,
+  createQuotaSnapshot,
+  parseQuotaSnapshot,
+  readQuotaCache,
+  writeQuotaCache
+};

--- a/tests/quota-cache.test.js
+++ b/tests/quota-cache.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  PERSISTED_QUOTA_TTL_MS,
+  createQuotaSnapshot,
+  parseQuotaSnapshot,
+  readQuotaCache,
+  writeQuotaCache
+} = require('../electron/quota-cache');
+
+const now = Date.parse('2026-09-01T13:00:00.000Z');
+const known = {
+  models: [{
+    id: 'claude',
+    name: 'Claude Code',
+    provider: 'Anthropic · Claude',
+    icon: 'claude',
+    quotaState: 'known',
+    authState: 'signed_in',
+    status: 'critical',
+    ringPercent: 89,
+    sessionUsedPercent: 36,
+    weeklyUsedPercent: 89,
+    sessionResetText: 'Resets in 1h',
+    weeklyResetText: 'Resets in 1d',
+    observedAt: new Date(now - 60_000).toISOString(),
+    accessToken: 'must-not-persist',
+    rawResponse: { secret: true }
+  }],
+  config: { customAgents: [{ command: 'private-command' }] }
+};
+
+test('snapshot persists only whitelisted quota display fields', () => {
+  const snapshot = createQuotaSnapshot(known, now);
+  assert.equal(snapshot.models.length, 1);
+  assert.equal(snapshot.models[0].weeklyUsedPercent, 89);
+  assert.equal(snapshot.models[0].accessToken, undefined);
+  assert.equal(snapshot.models[0].rawResponse, undefined);
+  assert.equal(snapshot.config, undefined);
+  assert.doesNotMatch(JSON.stringify(snapshot), /must-not-persist|private-command|secret/);
+});
+
+test('persisted readings load as stale and expire after the bounded TTL', () => {
+  const snapshot = createQuotaSnapshot(known, now);
+  const loaded = parseQuotaSnapshot(snapshot, now);
+  assert.equal(loaded.models[0].ringPercent, 89);
+  assert.equal(loaded.models[0].stale, true);
+  assert.equal(loaded.models[0].staleAgeMs, 60_000);
+  assert.equal(
+    parseQuotaSnapshot(snapshot, now + PERSISTED_QUOTA_TTL_MS + 1),
+    null
+  );
+});
+
+test('cache file round-trips atomically and malformed files fail closed', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-notch-cache-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, 'quota-cache.json');
+  assert.equal(writeQuotaCache(filePath, known, now), true);
+  const loaded = readQuotaCache(filePath, now);
+  assert.equal(loaded.models[0].sessionUsedPercent, 36);
+  assert.equal(fs.existsSync(`${filePath}.${process.pid}.tmp`), false);
+
+  fs.writeFileSync(filePath, '{not-json', 'utf8');
+  assert.equal(readQuotaCache(filePath, now), null);
+});
+
+test('unknown-only data never overwrites the last successful snapshot', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-notch-cache-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, 'quota-cache.json');
+  assert.equal(writeQuotaCache(filePath, known, now), true);
+  const before = fs.readFileSync(filePath, 'utf8');
+  assert.equal(writeQuotaCache(filePath, { models: [{ id: 'claude', quotaState: 'unknown' }] }, now), false);
+  assert.equal(fs.readFileSync(filePath, 'utf8'), before);
+});


### PR DESCRIPTION
## Summary

- persist the last successful quota readings across Agent Notch restarts
- restore them immediately as visibly stale while live provider refreshes run
- keep stale readings bounded to 24 hours
- never replace a successful snapshot with unknown-only data
- whitelist display-only fields so tokens, account data, raw responses, config, prompts, and command output are not cached

## Why

Claude quota is read from Anthropic's OAuth usage endpoint, not from the terminal process itself. A Notch restart or transient first fetch currently clears the RAM-only last-known state, briefly replacing a valid reading with a dash until the next successful poll.

## Verification

- `npm test` — 22/22 passing
- `npm run smoke:logic` — passing
- `npm run build` — passing
- `npm run pack:check` — passing
- cache round-trip, TTL expiry, malformed-file, unknown-overwrite, and secret-exclusion regression tests included