### PR TITLE
Toast when quota crosses while the rail is tucked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [Unreleased]
+
+### Added
+
+- Desktop toast when a quota crosses the critical threshold while the rail is tucked or hidden. Click the toast to reveal the HUD. Settings: **Notify when tucked**.
+
 ## [1.1.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Agent Notch detects and tracks live usage for major coding agent ecosystems dire
   - 🔴 **Critical (80%+)**: Imminent rate-limit window.
 - **Hover Popover Cards**: Detailed dual-meter breakdown (Session vs. Weekly/Monthly) with exact humanized reset countdowns (e.g. *“Resets in 2h 15m”*).
 - **Compact Viewport**: Four rings stay in view; extra rings scroll. Drag a ring to put your most-used agents on top.
-- **Settings Drawer**: Toggle which CLIs appear, set the alert threshold, add custom CLIs, and turn handoff animation off.
+- **Settings Drawer**: Toggle which CLIs appear, set the alert threshold, add custom CLIs, turn tuck notifications on/off, and turn handoff animation off.
 - **Edge Collapse**: Hover the rail for a right-facing chevron to tuck it; a left-facing chevron on the same-height remnant pulls it back. Notch remembers the last chosen state.
+- **Tuck Notifications**: If a quota crosses the critical threshold while the rail is tucked or hidden, Windows shows a desktop toast. Click it to reveal the HUD. Expanded rings already show red, so those stay silent.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,10 +56,8 @@ MindSync dispatch has preemptive readers and headroom ranking. Notch stays a spe
 - [x] One-click Windows install (`install.bat` / `install.ps1`) plus `npm i -g github:adityarya24/agent-notch`.
 - [x] Antigravity Google OAuth client via env / gitignored `.env` (same names as MindSync).
 - [ ] Packaged NSIS installer (Windows; macOS later).
-- [ ] Desktop notification when an account crosses the alert threshold. The ring
-  already turns red, but a tucked rail is invisible — that is the case worth
-  interrupting for. Silent when MindSync is attached, since the job moves on its
-  own and there is nothing to act on. Asked for on X, 2026-08-31.
+- [x] Desktop notification when an account crosses the alert threshold while the
+  rail is tucked or hidden. Standalone; no MindSync hook. Asked for on X, 2026-08-31.
 
 ---
 

--- a/electron/alert-notify.js
+++ b/electron/alert-notify.js
@@ -1,0 +1,97 @@
+const REARM_OFFSET = 3;
+
+function isUsable(model) {
+  if (!model || model.quotaState !== 'known' || model.stale) return false;
+  return Number.isFinite(Number(model.ringPercent));
+}
+
+function thresholdOf(model, fallback = 80) {
+  const raw = Number(model && model.alertThreshold);
+  if (Number.isFinite(raw)) return Math.max(50, Math.min(100, raw));
+  const base = Number(fallback);
+  return Number.isFinite(base) ? Math.max(50, Math.min(100, base)) : 80;
+}
+
+function dominantWindow(model) {
+  const session = Number(model && model.sessionUsedPercent);
+  const weekly = Number(model && model.weeklyUsedPercent);
+  const sessionOk = Number.isFinite(session);
+  const weeklyOk = Number.isFinite(weekly);
+  if (sessionOk && weeklyOk) {
+    return session >= weekly
+      ? { percent: session, label: 'session' }
+      : { percent: weekly, label: 'weekly' };
+  }
+  if (sessionOk) return { percent: session, label: 'session' };
+  if (weeklyOk) return { percent: weekly, label: 'weekly' };
+  return { percent: Number(model && model.ringPercent), label: 'quota' };
+}
+
+function formatAlertBody(event) {
+  const name = String((event && event.name) || (event && event.id) || 'Agent');
+  const percent = Math.round(Number(event && event.percent));
+  const label = String((event && event.window) || 'quota');
+  return `${name} hit ${percent}% (${label})`;
+}
+
+function evaluateQuotaAlerts({
+  previousModels = [],
+  nextModels = [],
+  visible = true,
+  notifyEnabled = true,
+  firedIds = [],
+  defaultThreshold = 80
+} = {}) {
+  const fired = new Set(Array.isArray(firedIds) ? firedIds : []);
+  const events = [];
+  const prevById = Object.fromEntries(
+    (Array.isArray(previousModels) ? previousModels : [])
+      .filter((model) => model && model.id)
+      .map((model) => [model.id, model])
+  );
+
+  for (const next of Array.isArray(nextModels) ? nextModels : []) {
+    if (!next || !next.id) continue;
+    const threshold = thresholdOf(next, defaultThreshold);
+    const rearmAt = threshold - REARM_OFFSET;
+    const usable = isUsable(next);
+    const percent = usable ? Number(next.ringPercent) : null;
+
+    if (usable && percent <= rearmAt) fired.delete(next.id);
+
+    if (!usable) continue;
+
+    if (percent < threshold) continue;
+
+    if (!notifyEnabled || visible) {
+      fired.add(next.id);
+      continue;
+    }
+
+    if (fired.has(next.id)) continue;
+
+    const prev = prevById[next.id];
+    if (!isUsable(prev) || Number(prev.ringPercent) >= threshold) {
+      fired.add(next.id);
+      continue;
+    }
+
+    const windowInfo = dominantWindow(next);
+    events.push({
+      id: next.id,
+      name: next.name || next.id,
+      percent: Math.round(percent),
+      window: windowInfo.label
+    });
+    fired.add(next.id);
+  }
+
+  return { events, firedIds: [...fired] };
+}
+
+module.exports = {
+  REARM_OFFSET,
+  dominantWindow,
+  evaluateQuotaAlerts,
+  formatAlertBody
+};

--- a/electron/config.js
+++ b/electron/config.js
@@ -9,7 +9,8 @@ const DEFAULT_CONFIG = Object.freeze({
   customAgents: Object.freeze([]),
   alertThreshold: 80,
   reduceMotion: false,
-  collapsed: false
+  collapsed: false,
+  notifyWhenTucked: true
 });
 const QUOTA_SOURCES = new Set(['unknown', 'manual', 'command']);
 const ICONS = new Set(['spark', 'claude', 'codex', 'gemini', 'cursor', 'grok', 'opencode']);
@@ -88,6 +89,7 @@ function sanitizeConfig(value) {
     alertThreshold,
     reduceMotion: Boolean(source.reduceMotion),
     collapsed: Boolean(source.collapsed),
+    notifyWhenTucked: source.notifyWhenTucked === undefined ? true : Boolean(source.notifyWhenTucked),
     modelOrder: sanitizeModelOrder(source.modelOrder, allowedIds)
   };
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,9 +1,10 @@
-const { app, BrowserWindow, screen, ipcMain, Tray, Menu, globalShortcut, nativeImage, session } = require('electron');
+const { app, BrowserWindow, screen, ipcMain, Tray, Menu, globalShortcut, nativeImage, session, Notification } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
 const fs = require('fs');
 const { getAllInstalledAgentUsage, getLocalConfig, saveLocalConfig, probeCli, suggestCustomClis } = require('./scrapers');
 const { readJobActivity } = require('./handoff_status');
+const { evaluateQuotaAlerts, formatAlertBody } = require('./alert-notify');
 const { runtimePath, ensureRuntimeDir, writePid, clearPid } = require('./runtime-state');
 const { activityFingerprint, quotaFingerprint, keepLastKnown } = require('./quota-state');
 const { PERSISTED_QUOTA_TTL_MS, readQuotaCache, writeQuotaCache } = require('./quota-cache');
@@ -16,8 +17,10 @@ let cachedQuotaState = null;
 let usageRefreshPromise = null;
 let overlayMode = 'dock';
 let overlayAnimation = null;
+let alertFiredIds = [];
 const logFile = runtimePath('electron_boot.log');
 const quotaCacheFile = runtimePath('quota-cache.json');
+const APP_USER_MODEL_ID = 'com.adityarya.agent-notch';
 
 const OVERLAY = {
   dock: { width: 360, height: 620 },
@@ -178,6 +181,50 @@ function publishState(next) {
   }
 }
 
+function ringsVisible() {
+  if (!mainWindow || mainWindow.isDestroyed() || !mainWindow.isVisible()) return false;
+  return overlayMode !== 'collapsed';
+}
+
+function revealNotch() {
+  const config = saveLocalConfig({ ...getLocalConfig(), collapsed: false });
+  snapOverlay('dock');
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (!mainWindow.isVisible()) mainWindow.show();
+    mainWindow.focus();
+    mainWindow.webContents.send('collapsed-changed', false);
+  }
+  if (cachedQuotaState) {
+    publishState({
+      ...cachedQuotaState,
+      config,
+      reduceMotion: reduceMotionEnabled(config)
+    });
+  }
+}
+
+function maybeNotifyQuotaAlerts(previous, next) {
+  const config = (next && next.config) || getLocalConfig();
+  const result = evaluateQuotaAlerts({
+    previousModels: previous && previous.models,
+    nextModels: next && next.models,
+    visible: ringsVisible(),
+    notifyEnabled: config.notifyWhenTucked !== false,
+    firedIds: alertFiredIds,
+    defaultThreshold: config.alertThreshold || 80
+  });
+  alertFiredIds = result.firedIds;
+  if (!result.events.length || !Notification.isSupported()) return;
+  for (const event of result.events) {
+    const note = new Notification({
+      title: 'Agent Notch',
+      body: formatAlertBody(event)
+    });
+    note.on('click', revealNotch);
+    note.show();
+  }
+}
+
 async function refreshUsageData({ force = false } = {}) {
   if (usageRefreshPromise) return usageRefreshPromise;
   usageRefreshPromise = (async () => {
@@ -193,6 +240,7 @@ async function refreshUsageData({ force = false } = {}) {
         scheduleJobPoll(merged.jobActivity);
         return cachedQuotaState;
       }
+      maybeNotifyQuotaAlerts(cachedQuotaState, merged);
       publishState(merged);
       scheduleJobPoll(merged.jobActivity);
       return merged;
@@ -394,6 +442,7 @@ async function runCaptureIfRequested() {
 }
 
 if (gotTheLock) app.whenReady().then(() => {
+  app.setAppUserModelId(APP_USER_MODEL_ID);
   try {
     ensureRuntimeDir();
     const persisted = readQuotaCache(quotaCacheFile);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -15,5 +15,10 @@ contextBridge.exposeInMainWorld('agentNotchAPI', {
     const subscription = (_event, data) => callback(data);
     ipcRenderer.on('usage-updated', subscription);
     return () => ipcRenderer.removeListener('usage-updated', subscription);
+  },
+  onCollapsedChanged: (callback) => {
+    const subscription = (_event, collapsed) => callback(collapsed);
+    ipcRenderer.on('collapsed-changed', subscription);
+    return () => ipcRenderer.removeListener('collapsed-changed', subscription);
   }
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,12 +44,19 @@ export default function App() {
       });
     }
 
+    const unsubs = [];
     if (window.agentNotchAPI?.onUsageUpdated) {
-      const unsub = window.agentNotchAPI.onUsageUpdated((newData) => {
+      unsubs.push(window.agentNotchAPI.onUsageUpdated((newData) => {
         if (newData && newData.models) setData(newData);
-      });
-      return () => unsub?.();
+      }));
     }
+    if (window.agentNotchAPI?.onCollapsedChanged) {
+      unsubs.push(window.agentNotchAPI.onCollapsedChanged((collapsed) => {
+        collapseInitialized.current = true;
+        setIsCollapsed(Boolean(collapsed));
+      }));
+    }
+    return () => unsubs.forEach((unsub) => unsub?.());
   }, []);
 
   useEffect(() => {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -42,6 +42,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
   });
   const [customAgents, setCustomAgents] = useState(Array.isArray(config?.customAgents) ? config.customAgents : []);
   const [reduceMotion, setReduceMotion] = useState(Boolean(config?.reduceMotion));
+  const [notifyWhenTucked, setNotifyWhenTucked] = useState(config?.notifyWhenTucked !== false);
   const [alertThreshold, setAlertThreshold] = useState(String(Number(config?.alertThreshold) || 80));
   const [showAdd, setShowAdd] = useState(false);
   const [draft, setDraft] = useState(emptyDraft());
@@ -92,6 +93,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
       enabledModels: nextEnabled || enabledMap,
       customAgents: nextCustom || customAgents,
       reduceMotion,
+      notifyWhenTucked,
       alertThreshold: normalizedThreshold()
     });
   };
@@ -365,6 +367,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
               enabledModels: enabledMap,
               customAgents,
               reduceMotion: next,
+              notifyWhenTucked,
               alertThreshold: normalizedThreshold()
             });
           }}
@@ -373,6 +376,27 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
           <span>Handoff animation</span>
           <span className={`px-1.5 py-0.5 rounded ${reduceMotion ? 'bg-white/10 text-neutral-500' : 'bg-emerald-500/20 text-emerald-300'}`}>
             {reduceMotion ? 'off' : 'on'}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            const next = !notifyWhenTucked;
+            setNotifyWhenTucked(next);
+            onSaveConfig({
+              ...config,
+              enabledModels: enabledMap,
+              customAgents,
+              reduceMotion,
+              notifyWhenTucked: next,
+              alertThreshold: normalizedThreshold()
+            });
+          }}
+          className="flex items-center justify-between px-1 py-0.5 text-[10px] text-neutral-400"
+        >
+          <span>Notify when tucked</span>
+          <span className={`px-1.5 py-0.5 rounded ${notifyWhenTucked ? 'bg-emerald-500/20 text-emerald-300' : 'bg-white/10 text-neutral-500'}`}>
+            {notifyWhenTucked ? 'on' : 'off'}
           </span>
         </button>
         <button

--- a/tests/alert-notify.test.js
+++ b/tests/alert-notify.test.js
@@ -1,0 +1,154 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { evaluateQuotaAlerts, formatAlertBody } = require('../electron/alert-notify');
+
+function model(id, percent, extra = {}) {
+  return {
+    id,
+    name: extra.name || id,
+    quotaState: extra.quotaState || 'known',
+    stale: Boolean(extra.stale),
+    ringPercent: percent,
+    sessionUsedPercent: extra.sessionUsedPercent ?? percent,
+    weeklyUsedPercent: extra.weeklyUsedPercent ?? 10,
+    alertThreshold: extra.alertThreshold,
+    ...extra
+  };
+}
+
+function evalAlerts(partial) {
+  return evaluateQuotaAlerts({
+    visible: false,
+    notifyEnabled: true,
+    defaultThreshold: 80,
+    firedIds: [],
+    ...partial
+  });
+}
+
+test('first known reading arms but does not notify', () => {
+  const result = evalAlerts({
+    previousModels: [],
+    nextModels: [model('grok', 91)]
+  });
+  assert.deepEqual(result.events, []);
+  assert.deepEqual(result.firedIds, ['grok']);
+});
+
+test('crossing the threshold while tucked notifies once', () => {
+  const first = evalAlerts({
+    previousModels: [model('grok', 72)],
+    nextModels: [model('grok', 84, { sessionUsedPercent: 84, weeklyUsedPercent: 40 })]
+  });
+  assert.equal(first.events.length, 1);
+  assert.equal(first.events[0].id, 'grok');
+  assert.equal(first.events[0].percent, 84);
+  assert.equal(first.events[0].window, 'session');
+  assert.equal(formatAlertBody(first.events[0]), 'grok hit 84% (session)');
+
+  const second = evalAlerts({
+    previousModels: [model('grok', 84)],
+    nextModels: [model('grok', 88)],
+    firedIds: first.firedIds
+  });
+  assert.deepEqual(second.events, []);
+});
+
+test('expanded rings arm silently so a later tuck does not replay', () => {
+  const open = evalAlerts({
+    visible: true,
+    previousModels: [model('claude', 70)],
+    nextModels: [model('claude', 90)]
+  });
+  assert.deepEqual(open.events, []);
+  assert.ok(open.firedIds.includes('claude'));
+
+  const tucked = evalAlerts({
+    previousModels: [model('claude', 90)],
+    nextModels: [model('claude', 91)],
+    firedIds: open.firedIds
+  });
+  assert.deepEqual(tucked.events, []);
+});
+
+test('disabled notify still arms so turning it on is not a dump', () => {
+  const result = evalAlerts({
+    notifyEnabled: false,
+    previousModels: [model('codex', 60)],
+    nextModels: [model('codex', 95)]
+  });
+  assert.deepEqual(result.events, []);
+  assert.ok(result.firedIds.includes('codex'));
+});
+
+test('stale and unknown readings never notify', () => {
+  const stale = evalAlerts({
+    previousModels: [model('cursor', 70)],
+    nextModels: [model('cursor', 90, { stale: true })]
+  });
+  assert.deepEqual(stale.events, []);
+
+  const unknown = evalAlerts({
+    previousModels: [model('cursor', 70)],
+    nextModels: [model('cursor', 90, { quotaState: 'unknown' })]
+  });
+  assert.deepEqual(unknown.events, []);
+});
+
+test('weekly window is named when it is the ring max', () => {
+  const result = evalAlerts({
+    previousModels: [model('gemini', 50, { sessionUsedPercent: 20, weeklyUsedPercent: 50 })],
+    nextModels: [model('gemini', 81, { sessionUsedPercent: 20, weeklyUsedPercent: 81 })]
+  });
+  assert.equal(result.events[0].window, 'weekly');
+  assert.equal(formatAlertBody(result.events[0]), 'gemini hit 81% (weekly)');
+});
+
+test('hysteresis waits until quota falls 3 points under threshold', () => {
+  const fired = evalAlerts({
+    previousModels: [model('opencode', 70)],
+    nextModels: [model('opencode', 80)]
+  });
+  assert.equal(fired.events.length, 1);
+
+  const stillHot = evalAlerts({
+    previousModels: [model('opencode', 80)],
+    nextModels: [model('opencode', 78)],
+    firedIds: fired.firedIds
+  });
+  assert.deepEqual(stillHot.events, []);
+  assert.ok(stillHot.firedIds.includes('opencode'));
+
+  const cooled = evalAlerts({
+    previousModels: [model('opencode', 78)],
+    nextModels: [model('opencode', 77)],
+    firedIds: stillHot.firedIds
+  });
+  assert.ok(!cooled.firedIds.includes('opencode'));
+
+  const recross = evalAlerts({
+    previousModels: [model('opencode', 77)],
+    nextModels: [model('opencode', 80)],
+    firedIds: cooled.firedIds
+  });
+  assert.equal(recross.events.length, 1);
+});
+
+test('two accounts can cross in the same tick', () => {
+  const result = evalAlerts({
+    previousModels: [model('claude', 60), model('grok', 60)],
+    nextModels: [model('claude', 82), model('grok', 99)]
+  });
+  assert.deepEqual(result.events.map((event) => event.id), ['claude', 'grok']);
+});
+
+test('per-model alertThreshold is used when present', () => {
+  const result = evalAlerts({
+    defaultThreshold: 80,
+    previousModels: [model('custom_1', 50, { alertThreshold: 60 })],
+    nextModels: [model('custom_1', 61, { alertThreshold: 60 })]
+  });
+  assert.equal(result.events.length, 1);
+  assert.equal(result.events[0].id, 'custom_1');
+});

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -32,6 +32,7 @@ test('sanitizeConfig bounds untrusted values and preserves supported providers',
   assert.equal(result.alertThreshold, 100);
   assert.equal(result.reduceMotion, true);
   assert.equal(result.collapsed, true);
+  assert.equal(result.notifyWhenTucked, true);
   assert.equal(result.customAgents[0].name, 'Local Agent');
   assert.equal(result.customAgents[0].icon, 'spark');
   assert.equal(result.customAgents[0].sessionUsedPercent, 0);
@@ -78,6 +79,12 @@ test('saveLocalConfig writes sanitized JSON atomically', () => {
 test('new installs start expanded and a collapsed preference survives sanitization', () => {
   assert.equal(config.sanitizeConfig({}).collapsed, false);
   assert.equal(config.sanitizeConfig({ collapsed: true }).collapsed, true);
+});
+
+test('tuck notifications default on and can be switched off', () => {
+  assert.equal(config.sanitizeConfig({}).notifyWhenTucked, true);
+  assert.equal(config.sanitizeConfig({ notifyWhenTucked: false }).notifyWhenTucked, false);
+  assert.equal(config.sanitizeConfig({ notifyWhenTucked: 1 }).notifyWhenTucked, true);
 });
 
 test('modelOrder keeps known ids, drops junk, and dedupes', () => {


### PR DESCRIPTION
## Summary

- Windows desktop toast when a quota **crosses** the critical threshold and the HUD is tucked or hidden
- Silent while the rings are visible — red already does that job
- First reading / stale / unknown never notify; hysteresis stops 80/79 flicker
- Settings toggle **Notify when tucked** (default on)
- Click the toast to reveal the HUD
- Standalone. No MindSync hook.

This is the X request from 2026-08-31.

## Stacking

Base is `fix/persist-last-known-quota` (#6) because both PRs touch `electron/main.js`.

Merge order:
1. #5 Grok signed-in quota-unavailable (independent)
2. #6 Persist last-known quota
3. this PR (GitHub will retarget to `main` after #6 merges)

#5 does not overlap.

## Verification

- `npm test` — 32/32 passing (includes #6 cache tests + new alert tests)
- `npm run smoke:logic` — passing
- `npm run build` — passing