### PR TITLE
Glow active local agents and validate custom providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Agent Notch detects and tracks live usage for major coding agent ecosystems dire
 - **Settings Drawer**: Toggle which CLIs appear, set the alert threshold, add custom CLIs, turn tuck notifications on/off, and turn handoff animation off.
 - **Edge Collapse**: Hover the rail for a right-facing chevron to tuck it; a left-facing chevron on the same-height remnant pulls it back. Notch remembers the last chosen state.
 - **Tuck Notifications**: If a quota crosses the critical threshold while the rail is tucked or hidden, Windows shows a desktop toast. Click it to reveal the HUD. Expanded rings already show red, so those stay silent.
+- **Live Agent Glow**: Supported local CLI rings breathe in their own quota color when recent session writes or dedicated-process activity indicates work. Concurrent agents glow together with staggered timing; session contents never leave the machine and are not read for display.
 
 ---
 
@@ -99,7 +100,7 @@ Agent Notch detects and tracks live usage for major coding agent ecosystems dire
 
 If you also use [**MindSync**](https://github.com/adityarya24/mindsync-ai) for multi-agent task dispatch and automated failover across local and VPS agents, Notch automatically surfaces live orchestration status:
 
-- **Active Agent Glow**: The working ring breathes in its own quota color. No extra badge.
+- **Dispatch-Aware Glow**: A running MindSync job keeps its assigned agent ring active alongside any directly observed local CLI sessions.
 - **One-Shot Handoff Flash**: When MindSync transitions a task between agents (e.g. `codex → grok (quota exhausted)`), a non-intrusive 2–3s banner plays once and quietly settles.
 - **Pure Spectator**: Notch never touches job execution, task transfers, or dispatch — it purely reflects live state from `~/.mindsync/dispatch/jobs/`.
 
@@ -208,7 +209,7 @@ You can add any custom coding assistant or local LLM CLI to the dock via the Set
      }
      ```
    - **Manual Snapshot**: Set fixed percentage values for manual tracking.
-   - **Unmanaged**: Displays as an unmetered ring with active process detection.
+   - **Unmanaged**: Displays as an unmetered ring. Direct live glow currently targets the six built-in provider adapters.
 
 Custom quota commands run locally on each refresh. Only configure commands you trust.
 
@@ -219,7 +220,7 @@ Custom quota commands run locally on each refresh. Only configure commands you t
 - **Zero Interruption**: Frameless, transparent Electron overlay configured with OS-level click forwarding so your IDE, terminal, and browser interactions remain completely uninterrupted.
 - **Local-First Security**: Notch has no telemetry or tracking backend. Provider credentials are read locally and sent only to that provider's official usage, billing, or OAuth endpoint when needed to retrieve quota data.
 - **Credential Spectator Boundary**: Notch does not rewrite or refresh provider credential files. An expired Claude session asks you to sign in through Claude Code. Google token refresh, when explicitly configured, is held in memory.
-- **Job Spectator Boundary**: Notch never transfers jobs or controls MindSync execution; it only reads MindSync job metadata for the active glow and handoff flash.
+- **Activity Spectator Boundary**: Notch detects recent local CLI work from session-artifact timestamps plus dedicated-process name and CPU metadata. It never reads transcript contents for the glow, and none of this activity metadata is transmitted. MindSync metadata remains the source for dispatch glow and handoff flash.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ You can add any custom coding assistant or local LLM CLI to the dock via the Set
 
 1. Click the **Settings Gear** at the bottom of the dock.
 2. Under **Custom Agents**, click **Add Custom CLI**.
-3. Supply a **Display Name** and an optional executable name on your `PATH`.
+3. Supply a **Display Name** and, for automatic live glow, the CLI's native process/executable name (for example `aider`).
 4. Choose a Quota Source:
    - **Command Stdout**: Point to a command/script that outputs JSON:
      ```json
@@ -209,9 +209,10 @@ You can add any custom coding assistant or local LLM CLI to the dock via the Set
      }
      ```
    - **Manual Snapshot**: Set fixed percentage values for manual tracking.
-   - **Unmanaged**: Displays as an unmetered ring. Direct live glow currently targets the six built-in provider adapters.
+   - **Unmanaged**: Displays as an unmetered ring; it can still glow while its configured native CLI process is doing CPU work.
 
 Custom quota commands run locally on each refresh. Only configure commands you trust.
+Activity Process and JSON Quota Command are separate: the first is used only for local process activity, while the second supplies percentages. Notch intentionally does not infer activity from generic wrapper runtimes such as `node`, `python`, PowerShell, or `.cmd`/`.ps1` scripts because that could light the wrong provider ring.
 
 ---
 

--- a/electron/config.js
+++ b/electron/config.js
@@ -51,6 +51,8 @@ function sanitizeCustomAgent(value, index) {
   const id = /^custom_[A-Za-z0-9_-]+$/.test(rawId) ? rawId : `custom_${index}`;
   const quotaSource = QUOTA_SOURCES.has(value.quotaSource) ? value.quotaSource : 'unknown';
   const icon = ICONS.has(value.icon) ? value.icon : 'spark';
+  const command = boundedString(value.command, '', 1024);
+  const legacyActivityProcess = quotaSource === 'command' ? '' : command;
   return {
     id,
     name,
@@ -62,7 +64,8 @@ function sanitizeCustomAgent(value, index) {
     weeklyUsedPercent: boundedPercent(value.weeklyUsedPercent),
     sessionResetText: boundedString(value.sessionResetText, '', 120),
     weeklyResetText: boundedString(value.weeklyResetText, '', 120),
-    command: boundedString(value.command, '', 1024)
+    activityProcess: boundedString(value.activityProcess || legacyActivityProcess, '', 260),
+    command
   };
 }
 

--- a/electron/direct_activity.js
+++ b/electron/direct_activity.js
@@ -1,0 +1,141 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const DEFAULT_ACTIVITY_WINDOW_MS = 25 * 1000;
+const MAX_SCAN_ENTRIES = 5000;
+
+function sessionArtifact(relativePath, fileName) {
+  const rel = String(relativePath || '').replace(/\\/g, '/').toLowerCase();
+  const name = String(fileName || '').toLowerCase();
+  const parts = rel.split('/').filter(Boolean);
+  return {
+    codex: name.startsWith('rollout-') && name.endsWith('.jsonl'),
+    claude: parts.length === 2 && name.endsWith('.jsonl'),
+    grok: ['events.jsonl', 'updates.jsonl', 'summary.json', 'resources_state.json'].includes(name),
+    cursor: (rel.includes('/agent-transcripts/') && name.endsWith('.jsonl')) || name === 'worker.log',
+    cursorTranscript: name.endsWith('.jsonl'),
+    cursorWorker: name === 'worker.log',
+    gemini: ['conversation.db', 'conversation.db-wal', 'conversation.db-shm'].includes(name) ||
+      (/\.db(-wal|-shm)?$/.test(name) && parts.length <= 2),
+    opencode: ['opencode.db', 'opencode.db-wal', 'opencode.db-shm'].includes(name)
+  };
+}
+
+function latestArtifactMtime(root, ring, maxDepth, maxEntries = MAX_SCAN_ENTRIES) {
+  let latest = 0;
+  let visited = 0;
+  const walk = (dir, depth) => {
+    if (depth > maxDepth || visited >= maxEntries) return;
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (e) {
+      return;
+    }
+    for (const entry of entries) {
+      if (visited >= maxEntries) break;
+      visited += 1;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath, depth + 1);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const relative = path.relative(root, fullPath);
+      if (!sessionArtifact(relative, entry.name)[ring]) continue;
+      try {
+        latest = Math.max(latest, fs.statSync(fullPath).mtimeMs || 0);
+      } catch (e) {}
+    }
+  };
+  walk(root, 0);
+  return latest;
+}
+
+function sessionDayRoots(sessionsRoot, now) {
+  const days = new Set();
+  for (const offset of [0, 24 * 60 * 60 * 1000]) {
+    const date = new Date(now - offset);
+    const local = [date.getFullYear(), date.getMonth() + 1, date.getDate()];
+    const utc = [date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()];
+    for (const parts of [local, utc]) {
+      days.add(parts.map((part, index) => index ? String(part).padStart(2, '0') : String(part)).join('/'));
+    }
+  }
+  return [...days].map((day) => path.join(sessionsRoot, ...day.split('/')));
+}
+
+function childDirectories(root) {
+  try {
+    return fs.readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(root, entry.name));
+  } catch (e) {
+    return [];
+  }
+}
+
+function providerRoots(homeDir, env = process.env, now = Date.now()) {
+  const codexHome = String(env.CODEX_HOME || '').trim() || path.join(homeDir, '.codex');
+  const claudeHome = String(env.CLAUDE_CONFIG_DIR || '').trim() || path.join(homeDir, '.claude');
+  const grokHome = String(env.GROK_HOME || env.XAI_HOME || '').trim() || path.join(homeDir, '.grok');
+  const xdgDataHome = String(env.XDG_DATA_HOME || '').trim();
+  const opencodeHome = xdgDataHome ? path.join(xdgDataHome, 'opencode') : path.join(homeDir, '.local', 'share', 'opencode');
+  const cursorProjects = childDirectories(path.join(homeDir, '.cursor', 'projects'));
+  return [
+    ...sessionDayRoots(path.join(codexHome, 'sessions'), now).map((root) => ({ ring: 'codex', root, maxDepth: 0 })),
+    { ring: 'claude', root: path.join(claudeHome, 'projects'), maxDepth: 2 },
+    { ring: 'grok', root: path.join(grokHome, 'sessions'), maxDepth: 3 },
+    ...cursorProjects.map((root) => ({ ring: 'cursor', artifact: 'cursorWorker', root, maxDepth: 0 })),
+    ...cursorProjects.map((root) => ({ ring: 'cursor', artifact: 'cursorTranscript', root: path.join(root, 'agent-transcripts'), maxDepth: 2 })),
+    { ring: 'gemini', root: path.join(homeDir, '.gemini', 'antigravity-cli', 'conversations'), maxDepth: 2 },
+    { ring: 'gemini', root: path.join(homeDir, '.gemini', 'antigravity', 'conversations'), maxDepth: 2 },
+    { ring: 'opencode', root: opencodeHome, maxDepth: 0 }
+  ];
+}
+
+function readDirectAgentActivity({
+  homeDir = os.homedir(),
+  now = Date.now(),
+  freshnessMs = DEFAULT_ACTIVITY_WINDOW_MS,
+  roots = providerRoots(homeDir, process.env, now),
+  includeRings = null
+} = {}) {
+  const included = includeRings ? new Set(includeRings) : null;
+  const latestByRing = new Map();
+  for (const spec of roots) {
+    if (included && !included.has(spec.ring)) continue;
+    const mtimeMs = latestArtifactMtime(spec.root, spec.artifact || spec.ring, spec.maxDepth);
+    if (!mtimeMs || now - mtimeMs > freshnessMs || mtimeMs - now > 5000) continue;
+    latestByRing.set(spec.ring, Math.max(latestByRing.get(spec.ring) || 0, mtimeMs));
+  }
+  return [...latestByRing.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([activeRing, mtimeMs]) => ({
+      activeRing,
+      source: 'local-session',
+      lastActivityAt: new Date(mtimeMs).toISOString()
+    }));
+}
+
+function mergeActiveRings(jobActivity, directActivities) {
+  const rings = new Set();
+  if (jobActivity && jobActivity.jobStatus === 'running' && jobActivity.activeRing) {
+    rings.add(jobActivity.activeRing);
+  }
+  for (const activity of directActivities || []) {
+    if (activity && activity.activeRing) rings.add(activity.activeRing);
+  }
+  return [...rings].sort();
+}
+
+module.exports = {
+  childDirectories,
+  DEFAULT_ACTIVITY_WINDOW_MS,
+  latestArtifactMtime,
+  mergeActiveRings,
+  providerRoots,
+  readDirectAgentActivity,
+  sessionDayRoots
+};

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 const { getAllInstalledAgentUsage, getLocalConfig, saveLocalConfig, probeCli, suggestCustomClis } = require('./scrapers');
 const { readJobActivity } = require('./handoff_status');
 const { evaluateQuotaAlerts, formatAlertBody } = require('./alert-notify');
+const { mergeActiveRings, readDirectAgentActivity } = require('./direct_activity');
+const { ProcessActivityTracker } = require('./process_activity');
 const { runtimePath, ensureRuntimeDir, writePid, clearPid } = require('./runtime-state');
 const { activityFingerprint, quotaFingerprint, keepLastKnown } = require('./quota-state');
 const { PERSISTED_QUOTA_TTL_MS, readQuotaCache, writeQuotaCache } = require('./quota-cache');
@@ -21,6 +23,14 @@ let alertFiredIds = [];
 const logFile = runtimePath('electron_boot.log');
 const quotaCacheFile = runtimePath('quota-cache.json');
 const APP_USER_MODEL_ID = 'com.adityarya.agent-notch';
+const processActivity = new ProcessActivityTracker();
+
+function readLocalActivities() {
+  // Cursor Agent and OpenCode can run behind node.exe shims, so their narrow
+  // artifact adapters stay enabled even when no dedicated process name exists.
+  const includeRings = [...new Set([...processActivity.liveRings(), 'cursor', 'gemini', 'opencode'])];
+  return [...readDirectAgentActivity({ includeRings }), ...processActivity.current()];
+}
 
 const OVERLAY = {
   dock: { width: 360, height: 620 },
@@ -160,18 +170,20 @@ function createOverlayWindow() {
 
 function attachActivity(data) {
   const activity = readJobActivity();
+  const directActivities = readLocalActivities();
   data.jobActivity = activity;
+  data.activeRings = mergeActiveRings(activity, directActivities);
   data.handoff = activity && activity.handoff ? activity.handoff : null;
   data.reduceMotion = reduceMotionEnabled(data.config || getLocalConfig());
   return data;
 }
 
-function scheduleJobPoll(activity) {
+function scheduleJobPoll(activeRings = [], delayOverride = null) {
   if (jobPollTimer) clearTimeout(jobPollTimer);
-  const ms = activity && activity.jobStatus === 'running' ? 2500 : 15000;
+  const delay = delayOverride ?? (activeRings.length ? 3000 : 7500);
   jobPollTimer = setTimeout(() => {
     refreshJobActivity();
-  }, ms);
+  }, delay);
 }
 
 function publishState(next) {
@@ -232,17 +244,18 @@ async function refreshUsageData({ force = false } = {}) {
       const liveData = attachActivity(await getAllInstalledAgentUsage({ force }));
       const merged = keepLastKnown(cachedQuotaState, liveData, Date.now(), PERSISTED_QUOTA_TTL_MS);
       merged.jobActivity = liveData.jobActivity;
+      merged.activeRings = liveData.activeRings;
       merged.handoff = liveData.handoff;
       merged.reduceMotion = liveData.reduceMotion;
       writeQuotaCache(quotaCacheFile, merged);
       if (cachedQuotaState && quotaFingerprint(cachedQuotaState) === quotaFingerprint(merged)) {
         cachedQuotaState = { ...merged, lastUpdated: liveData.lastUpdated };
-        scheduleJobPoll(merged.jobActivity);
+        scheduleJobPoll(merged.activeRings);
         return cachedQuotaState;
       }
       maybeNotifyQuotaAlerts(cachedQuotaState, merged);
       publishState(merged);
-      scheduleJobPoll(merged.jobActivity);
+      scheduleJobPoll(merged.activeRings);
       return merged;
     } catch (err) {
       console.error('[Agent Notch] Error refreshing quota:', err);
@@ -254,30 +267,33 @@ async function refreshUsageData({ force = false } = {}) {
   return usageRefreshPromise;
 }
 
-function refreshJobActivity() {
+async function refreshJobActivity() {
   try {
     if (!cachedQuotaState) {
       refreshUsageData();
       return;
     }
+    await processActivity.sample();
     const activity = readJobActivity();
+    const activeRings = mergeActiveRings(activity, readLocalActivities());
     const reduceMotion = reduceMotionEnabled(cachedQuotaState.config || getLocalConfig());
-    const prev = activityFingerprint(cachedQuotaState.jobActivity);
-    const next = activityFingerprint(activity);
+    const prev = activityFingerprint(cachedQuotaState.jobActivity, cachedQuotaState.activeRings);
+    const next = activityFingerprint(activity, activeRings);
     if (prev === next && Boolean(cachedQuotaState.reduceMotion) === reduceMotion) {
-      scheduleJobPoll(activity);
+      scheduleJobPoll(activeRings);
       return;
     }
     publishState({
       ...cachedQuotaState,
       jobActivity: activity,
+      activeRings,
       handoff: activity && activity.handoff ? activity.handoff : null,
       reduceMotion
     });
-    scheduleJobPoll(activity);
+    scheduleJobPoll(activeRings);
   } catch (err) {
     console.error('[Agent Notch] Error refreshing job activity:', err);
-    scheduleJobPoll(null);
+    scheduleJobPoll(cachedQuotaState?.activeRings || []);
   }
 }
 
@@ -475,7 +491,7 @@ if (gotTheLock) app.whenReady().then(() => {
   });
 
   pollInterval = setInterval(() => refreshUsageData(), 60000);
-  scheduleJobPoll(null);
+  processActivity.sample().finally(() => scheduleJobPoll([], 3000));
 });
 
 process.on('uncaughtException', (err) => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,7 +6,7 @@ const { getAllInstalledAgentUsage, getLocalConfig, saveLocalConfig, probeCli, su
 const { readJobActivity } = require('./handoff_status');
 const { evaluateQuotaAlerts, formatAlertBody } = require('./alert-notify');
 const { mergeActiveRings, readDirectAgentActivity } = require('./direct_activity');
-const { ProcessActivityTracker } = require('./process_activity');
+const { customProcessMappings, ProcessActivityTracker } = require('./process_activity');
 const { runtimePath, ensureRuntimeDir, writePid, clearPid } = require('./runtime-state');
 const { activityFingerprint, quotaFingerprint, keepLastKnown } = require('./quota-state');
 const { PERSISTED_QUOTA_TTL_MS, readQuotaCache, writeQuotaCache } = require('./quota-cache');
@@ -30,6 +30,13 @@ function readLocalActivities() {
   // artifact adapters stay enabled even when no dedicated process name exists.
   const includeRings = [...new Set([...processActivity.liveRings(), 'cursor', 'gemini', 'opencode'])];
   return [...readDirectAgentActivity({ includeRings }), ...processActivity.current()];
+}
+
+function configuredProcessMappings() {
+  // Activity settings must reflect the just-saved file even when a slower
+  // quota refresh is still resolving with its older config snapshot.
+  const config = getLocalConfig();
+  return customProcessMappings(config?.customAgents);
 }
 
 const OVERLAY = {
@@ -273,7 +280,7 @@ async function refreshJobActivity() {
       refreshUsageData();
       return;
     }
-    await processActivity.sample();
+    await processActivity.sample(configuredProcessMappings());
     const activity = readJobActivity();
     const activeRings = mergeActiveRings(activity, readLocalActivities());
     const reduceMotion = reduceMotionEnabled(cachedQuotaState.config || getLocalConfig());
@@ -491,7 +498,7 @@ if (gotTheLock) app.whenReady().then(() => {
   });
 
   pollInterval = setInterval(() => refreshUsageData(), 60000);
-  processActivity.sample().finally(() => scheduleJobPoll([], 3000));
+  processActivity.sample(configuredProcessMappings()).finally(() => scheduleJobPoll([], 3000));
 });
 
 process.on('uncaughtException', (err) => {

--- a/electron/process_activity.js
+++ b/electron/process_activity.js
@@ -1,15 +1,62 @@
 const { execFile } = require('child_process');
-const path = require('path');
 
 const PROCESS_GRACE_MS = 15 * 1000;
 const MIN_CPU_DELTA_SECONDS = 0.01;
+const BUILTIN_PROCESS_NAMES = ['codex', 'claude', 'grok', 'opencode', 'gemini', 'agy', 'antigravity-cli', 'cursor-agent'];
+const GENERIC_PROCESS_NAMES = new Set([
+  'bash', 'bun', 'cmd', 'deno', 'dotnet', 'fish', 'java', 'javaw', 'perl', 'php',
+  'powershell', 'pwsh', 'ruby', 'sh', 'zsh'
+]);
+
+function normalizeProcessName(rawName) {
+  return String(rawName || '')
+    .trim()
+    .split(/[\\/]/)
+    .pop()
+    .replace(/\.exe$/i, '')
+    .toLowerCase();
+}
 
 function ringForProcess(rawName) {
-  const name = path.basename(String(rawName || '')).replace(/\.exe$/i, '').toLowerCase();
+  const name = normalizeProcessName(rawName);
   if (['codex', 'claude', 'grok', 'opencode'].includes(name)) return name;
   if (['gemini', 'agy', 'antigravity-cli'].includes(name)) return 'gemini';
   if (name === 'cursor-agent') return 'cursor';
   return null;
+}
+
+function activityExecutable(rawCommand) {
+  const text = String(rawCommand || '').trim();
+  if (!text) return null;
+  const quoted = text.match(/^"([^"]+)"$/);
+  const executable = quoted ? quoted[1] : (/\s/.test(text) ? '' : text);
+  if (!executable || /\.(?:bat|cmd|ps1|sh)$/i.test(executable)) return null;
+  const name = normalizeProcessName(executable);
+  if (GENERIC_PROCESS_NAMES.has(name) || /^node(?:js)?(?:\d+(?:\.\d+)*)?$/.test(name) || /^pythonw?(?:\d+(?:\.\d+)*)?$/.test(name)) return null;
+  return /^[a-z0-9._-]{1,80}$/.test(name) ? name : null;
+}
+
+function customProcessMappings(customAgents) {
+  const mappings = Object.create(null);
+  for (const agent of customAgents || []) {
+    const id = String(agent?.id || '');
+    if (!/^custom_[A-Za-z0-9_-]+$/.test(id)) continue;
+    const name = activityExecutable(agent.activityProcess);
+    if (!name) continue;
+    mappings[name] = [...new Set([...(mappings[name] || []), id])];
+  }
+  return mappings;
+}
+
+function ringsForProcess(rawName, customMappings = {}) {
+  const name = normalizeProcessName(rawName);
+  const rings = new Set();
+  const builtin = ringForProcess(name);
+  if (builtin) rings.add(builtin);
+  const customRings = Object.prototype.hasOwnProperty.call(customMappings || {}, name)
+    && Array.isArray(customMappings[name]) ? customMappings[name] : [];
+  for (const id of customRings) rings.add(id);
+  return [...rings];
 }
 
 function cpuTimeSeconds(raw) {
@@ -61,9 +108,13 @@ function execSamples(file, args, parser) {
   });
 }
 
-function sampleAgentProcesses(platform = process.platform) {
+function sampleAgentProcesses(extraNames = [], platform = process.platform) {
   if (platform === 'win32') {
-    const command = "Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -in @('codex','claude','grok','opencode','gemini','agy','antigravity-cli','cursor-agent') } | Select-Object ProcessName,Id,CPU | ConvertTo-Json -Compress";
+    const names = [...new Set([...BUILTIN_PROCESS_NAMES, ...extraNames])]
+      .map(normalizeProcessName)
+      .filter((name) => /^[a-z0-9._-]{1,80}$/.test(name));
+    const literals = names.map((name) => `'${name}'`).join(',');
+    const command = `Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -in @(${literals}) } | Select-Object ProcessName,Id,CPU | ConvertTo-Json -Compress`;
     return execSamples('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command], parseWindowsSamples);
   }
   return execSamples('ps', ['-A', '-o', 'pid=,comm=,time='], parseUnixSamples);
@@ -98,22 +149,24 @@ class ProcessActivityTracker {
     return [...this.live].sort();
   }
 
-  sample() {
+  sample(customMappings = {}) {
     if (this.pending) return this.pending;
-    this.pending = Promise.resolve(this.sampler()).then((samples) => {
+    this.pending = Promise.resolve(this.sampler(Object.keys(customMappings))).then((samples) => {
       const now = this.now();
       const nextCpu = new Map();
       const liveRings = new Set();
       for (const row of samples || []) {
-        const ring = ringForProcess(row.name);
-        if (!ring || !Number.isFinite(row.pid) || !Number.isFinite(row.cpuSeconds)) continue;
-        liveRings.add(ring);
-        const key = `${ring}:${row.pid}`;
-        const previous = this.previousCpu.get(key);
-        if (Number.isFinite(previous) && row.cpuSeconds - previous >= this.minCpuDeltaSeconds) {
-          this.activeUntil.set(ring, now + this.graceMs);
+        const rings = ringsForProcess(row.name, customMappings);
+        if (!rings.length || !Number.isFinite(row.pid) || !Number.isFinite(row.cpuSeconds)) continue;
+        for (const ring of rings) {
+          liveRings.add(ring);
+          const key = `${ring}:${row.pid}`;
+          const previous = this.previousCpu.get(key);
+          if (Number.isFinite(previous) && row.cpuSeconds - previous >= this.minCpuDeltaSeconds) {
+            this.activeUntil.set(ring, now + this.graceMs);
+          }
+          nextCpu.set(key, row.cpuSeconds);
         }
-        nextCpu.set(key, row.cpuSeconds);
       }
       for (const ring of this.activeUntil.keys()) {
         if (!liveRings.has(ring)) this.activeUntil.delete(ring);
@@ -129,12 +182,17 @@ class ProcessActivityTracker {
 }
 
 module.exports = {
+  BUILTIN_PROCESS_NAMES,
   MIN_CPU_DELTA_SECONDS,
   PROCESS_GRACE_MS,
   ProcessActivityTracker,
+  activityExecutable,
   cpuTimeSeconds,
+  customProcessMappings,
+  normalizeProcessName,
   parseUnixSamples,
   parseWindowsSamples,
   ringForProcess,
+  ringsForProcess,
   sampleAgentProcesses
 };

--- a/electron/process_activity.js
+++ b/electron/process_activity.js
@@ -1,0 +1,140 @@
+const { execFile } = require('child_process');
+const path = require('path');
+
+const PROCESS_GRACE_MS = 15 * 1000;
+const MIN_CPU_DELTA_SECONDS = 0.01;
+
+function ringForProcess(rawName) {
+  const name = path.basename(String(rawName || '')).replace(/\.exe$/i, '').toLowerCase();
+  if (['codex', 'claude', 'grok', 'opencode'].includes(name)) return name;
+  if (['gemini', 'agy', 'antigravity-cli'].includes(name)) return 'gemini';
+  if (name === 'cursor-agent') return 'cursor';
+  return null;
+}
+
+function cpuTimeSeconds(raw) {
+  const text = String(raw || '').trim();
+  const daySplit = text.split('-');
+  if (daySplit.length > 2) return null;
+  const days = daySplit.length === 2 ? Number(daySplit[0]) : 0;
+  const parts = daySplit[daySplit.length - 1].split(':').map(Number);
+  if (!Number.isFinite(days)) return null;
+  if (!parts.length || parts.some((part) => !Number.isFinite(part))) return null;
+  let clockSeconds = 0;
+  for (const part of parts) clockSeconds = (clockSeconds * 60) + part;
+  return (days * 24 * 60 * 60) + clockSeconds;
+}
+
+function parseWindowsSamples(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    return [];
+  }
+  return (Array.isArray(parsed) ? parsed : [parsed]).map((row) => ({
+    pid: Number(row.Id),
+    name: String(row.ProcessName || ''),
+    cpuSeconds: Number(row.CPU)
+  })).filter((row) => Number.isFinite(row.pid) && Number.isFinite(row.cpuSeconds));
+}
+
+function parseUnixSamples(stdout) {
+  const rows = [];
+  for (const line of String(stdout || '').split(/\r?\n/)) {
+    const match = line.trim().match(/^(\d+)\s+(\S+)\s+([\d:-]+)$/);
+    if (!match) continue;
+    const cpuSeconds = cpuTimeSeconds(match[3]);
+    if (!Number.isFinite(cpuSeconds)) continue;
+    rows.push({ pid: Number(match[1]), name: match[2], cpuSeconds });
+  }
+  return rows;
+}
+
+function execSamples(file, args, parser) {
+  return new Promise((resolve) => {
+    execFile(file, args, { windowsHide: true, timeout: 2500, maxBuffer: 256 * 1024 }, (error, stdout) => {
+      resolve(error ? [] : parser(stdout));
+    });
+  });
+}
+
+function sampleAgentProcesses(platform = process.platform) {
+  if (platform === 'win32') {
+    const command = "Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -in @('codex','claude','grok','opencode','gemini','agy','antigravity-cli','cursor-agent') } | Select-Object ProcessName,Id,CPU | ConvertTo-Json -Compress";
+    return execSamples('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command], parseWindowsSamples);
+  }
+  return execSamples('ps', ['-A', '-o', 'pid=,comm=,time='], parseUnixSamples);
+}
+
+class ProcessActivityTracker {
+  constructor({
+    sampler = sampleAgentProcesses,
+    now = () => Date.now(),
+    graceMs = PROCESS_GRACE_MS,
+    minCpuDeltaSeconds = MIN_CPU_DELTA_SECONDS
+  } = {}) {
+    this.sampler = sampler;
+    this.now = now;
+    this.graceMs = graceMs;
+    this.minCpuDeltaSeconds = minCpuDeltaSeconds;
+    this.previousCpu = new Map();
+    this.activeUntil = new Map();
+    this.live = new Set();
+    this.pending = null;
+  }
+
+  current() {
+    const now = this.now();
+    return [...this.activeUntil.entries()]
+      .filter(([, until]) => until >= now)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([activeRing]) => ({ activeRing, source: 'local-process' }));
+  }
+
+  liveRings() {
+    return [...this.live].sort();
+  }
+
+  sample() {
+    if (this.pending) return this.pending;
+    this.pending = Promise.resolve(this.sampler()).then((samples) => {
+      const now = this.now();
+      const nextCpu = new Map();
+      const liveRings = new Set();
+      for (const row of samples || []) {
+        const ring = ringForProcess(row.name);
+        if (!ring || !Number.isFinite(row.pid) || !Number.isFinite(row.cpuSeconds)) continue;
+        liveRings.add(ring);
+        const key = `${ring}:${row.pid}`;
+        const previous = this.previousCpu.get(key);
+        if (Number.isFinite(previous) && row.cpuSeconds - previous >= this.minCpuDeltaSeconds) {
+          this.activeUntil.set(ring, now + this.graceMs);
+        }
+        nextCpu.set(key, row.cpuSeconds);
+      }
+      for (const ring of this.activeUntil.keys()) {
+        if (!liveRings.has(ring)) this.activeUntil.delete(ring);
+      }
+      this.live = liveRings;
+      this.previousCpu = nextCpu;
+      return this.current();
+    }).catch(() => this.current()).finally(() => {
+      this.pending = null;
+    });
+    return this.pending;
+  }
+}
+
+module.exports = {
+  MIN_CPU_DELTA_SECONDS,
+  PROCESS_GRACE_MS,
+  ProcessActivityTracker,
+  cpuTimeSeconds,
+  parseUnixSamples,
+  parseWindowsSamples,
+  ringForProcess,
+  sampleAgentProcesses
+};

--- a/electron/quota-state.js
+++ b/electron/quota-state.js
@@ -1,9 +1,10 @@
 const DEFAULT_STALE_TTL_MS = 5 * 60 * 1000;
 
-function activityFingerprint(activity) {
-  if (!activity) return '';
+function activityFingerprint(activity, activeRings = []) {
+  const rings = [...new Set(activeRings || [])].sort().join(',');
+  if (!activity) return rings;
   const handoff = activity.handoff;
-  return `${activity.jobId || ''}:${activity.jobStatus || ''}:${activity.activeAgent || ''}:${handoff ? `${handoff.at}:${handoff.from}->${handoff.to}` : ''}`;
+  return `${rings}|${activity.jobId || ''}:${activity.jobStatus || ''}:${activity.activeAgent || ''}:${handoff ? `${handoff.at}:${handoff.from}->${handoff.to}` : ''}`;
 }
 
 function quotaFingerprint(data) {
@@ -21,7 +22,7 @@ function quotaFingerprint(data) {
       model.lastError || ''
     ].join(':'))
     .join('|');
-  return `${models}|${activityFingerprint(data.jobActivity)}`;
+  return `${models}|${activityFingerprint(data.jobActivity, data.activeRings)}`;
 }
 
 function keepLastKnown(previous, next, now = Date.now(), staleTtlMs = DEFAULT_STALE_TTL_MS) {

--- a/electron/scrapers.js
+++ b/electron/scrapers.js
@@ -3,7 +3,7 @@ const path = require('path');
 const https = require('https');
 const os = require('os');
 const { URL } = require('url');
-const { execFile } = require('child_process');
+const { exec, execFile } = require('child_process');
 const { DEFAULT_CONFIG, getLocalConfig, saveLocalConfig } = require('./config');
 const { sortModelsByOrder } = require('./model-order');
 
@@ -1197,9 +1197,8 @@ function runQuotaCommand(command) {
       resolve(null);
       return;
     }
-    const child = execFile(
-      process.platform === 'win32' ? 'cmd.exe' : 'sh',
-      process.platform === 'win32' ? ['/d', '/s', '/c', trimmed] : ['-c', trimmed],
+    const child = exec(
+      trimmed,
       { timeout: 5000, maxBuffer: 64 * 1024, windowsHide: true },
       (err, stdout) => {
         if (err) {
@@ -1339,7 +1338,7 @@ async function suggestCustomClis(config) {
   const custom = Array.isArray(config?.customAgents) ? config.customAgents : [];
   const taken = new Set(
     custom
-      .map((agent) => String(agent.command || agent.name || '').trim().toLowerCase())
+      .map((agent) => String(agent.activityProcess || agent.command || agent.name || '').trim().toLowerCase())
       .filter(Boolean)
   );
   const results = [];

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,6 +124,10 @@ export default function App() {
   };
 
   const job = data.jobActivity && data.jobActivity.jobStatus === 'running' ? data.jobActivity : null;
+  const activeRings = useMemo(() => new Set([
+    ...(data.activeRings || []),
+    ...(job?.activeRing ? [job.activeRing] : [])
+  ]), [data.activeRings, job?.activeRing]);
   const reduceMotion = Boolean(data.reduceMotion) || Boolean(data.config?.reduceMotion);
   configRef.current = data.config;
   saveRef.current = handleSaveConfig;
@@ -296,8 +300,8 @@ export default function App() {
           title={models.length > VISIBLE_RINGS ? 'Scroll for more · drag to reorder' : 'Drag to reorder'}
         >
           {models.length > 0 ? (
-            models.map((m) => {
-              const isWork = Boolean(job && job.activeRing === m.id);
+            models.map((m, index) => {
+              const isWork = activeRings.has(m.id);
               const isFrom = Boolean(flash && flash.fromRing === m.id);
               const isTo = Boolean(flash && flash.toRing === m.id);
               return (
@@ -323,6 +327,7 @@ export default function App() {
                   status={m.status || m.quotaState}
                   isActive={hoveredModelId === m.id}
                   isLive={isWork || isTo}
+                  liveDelayMs={index * -170}
                   reduceMotion={reduceMotion}
                 >
                   {getModelIcon(m.icon)}

--- a/src/components/CircularProgressRing.jsx
+++ b/src/components/CircularProgressRing.jsx
@@ -8,6 +8,7 @@ function CircularProgressRingInner({
   children,
   isActive = false,
   isLive = false,
+  liveDelayMs = 0,
   reduceMotion = false
 }) {
   const known = status !== 'unknown' && status !== 'expired' && progress != null;
@@ -40,7 +41,8 @@ function CircularProgressRingInner({
             style={{
               background: ringColor,
               opacity: reduceMotion ? 0.4 : undefined,
-              filter: 'blur(8px)'
+              filter: 'blur(8px)',
+              animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
             }}
           />
           <div
@@ -48,7 +50,8 @@ function CircularProgressRingInner({
             style={{
               background: ringColor,
               opacity: reduceMotion ? 0.28 : undefined,
-              filter: 'blur(4px)'
+              filter: 'blur(4px)',
+              animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
             }}
           />
         </>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -27,6 +27,7 @@ function emptyDraft() {
     quotaSource: 'unknown',
     sessionUsedPercent: '',
     weeklyUsedPercent: '',
+    activityProcess: '',
     command: ''
   };
 }
@@ -62,8 +63,8 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
       setProbe(null);
       return;
     }
-    const cmd = draft.command.trim();
-    if (!cmd || /\s/.test(cmd) || draft.quotaSource === 'command') {
+    const cmd = draft.activityProcess.trim();
+    if (!cmd || /\s/.test(cmd)) {
       setProbe(null);
       return;
     }
@@ -72,7 +73,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
       window.agentNotchAPI.probeCli(cmd).then(setProbe).catch(() => setProbe(null));
     }, 280);
     return () => clearTimeout(timer);
-  }, [draft.command, draft.quotaSource, showAdd]);
+  }, [draft.activityProcess, showAdd]);
 
   if (!isOpen) return null;
 
@@ -118,7 +119,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
 
   const addCustom = () => {
     const name = draft.name.trim();
-    if (!name) return;
+    if (!name || (draft.quotaSource === 'command' && !draft.command.trim())) return;
     addAgent({
       id: `custom_${Date.now().toString(36)}`,
       name,
@@ -128,7 +129,8 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
       quotaSource: draft.quotaSource || 'unknown',
       sessionUsedPercent: draft.sessionUsedPercent === '' ? null : Number(draft.sessionUsedPercent),
       weeklyUsedPercent: draft.weeklyUsedPercent === '' ? null : Number(draft.weeklyUsedPercent),
-      command: draft.command.trim()
+      activityProcess: draft.activityProcess.trim(),
+      command: draft.quotaSource === 'command' ? draft.command.trim() : ''
     });
     setDraft(emptyDraft());
     setShowAdd(false);
@@ -145,7 +147,8 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
       quotaSource: 'unknown',
       sessionUsedPercent: null,
       weeklyUsedPercent: null,
-      command: item.command
+      activityProcess: item.command,
+      command: ''
     });
   };
 
@@ -257,12 +260,12 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
               className="w-full bg-[#18181b] border border-white/10 rounded-lg px-2 py-1.5 text-xs text-white placeholder:text-neutral-500 outline-none focus:border-emerald-500/50"
             />
             <input
-              value={draft.command}
-              onChange={(e) => setDraft({ ...draft, command: e.target.value })}
-              placeholder={draft.quotaSource === 'command' ? 'Command that prints JSON percents' : 'CLI on PATH (optional, e.g. aider)'}
+              value={draft.activityProcess}
+              onChange={(e) => setDraft({ ...draft, activityProcess: e.target.value })}
+              placeholder="CLI process for glow (optional, e.g. aider)"
               className="w-full bg-[#18181b] border border-white/10 rounded-lg px-2 py-1.5 text-xs text-white placeholder:text-neutral-500 outline-none focus:border-emerald-500/50"
             />
-            {probe && draft.quotaSource !== 'command' && draft.command.trim() && (
+            {probe && draft.activityProcess.trim() && (
               <p className={`text-[10px] ${probe.found ? 'text-emerald-400' : 'text-amber-400'}`}>
                 {probe.found ? `Found: ${probe.path}` : 'Not on PATH — you can still add it, quota stays unknown'}
               </p>
@@ -295,6 +298,12 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
             </select>
             {draft.quotaSource === 'command' && (
               <div className="text-[10px] text-neutral-500 leading-snug">
+                <input
+                  value={draft.command}
+                  onChange={(e) => setDraft({ ...draft, command: e.target.value })}
+                  placeholder="Command that prints JSON percents"
+                  className="mb-1.5 w-full bg-[#18181b] border border-white/10 rounded-lg px-2 py-1.5 text-xs text-white placeholder:text-neutral-500 outline-none focus:border-emerald-500/50"
+                />
                 <p className="font-mono">{'{"sessionUsedPercent":12,"weeklyUsedPercent":40}'}</p>
                 <p className="mt-1 text-amber-400/80">Runs this local command when Notch refreshes. Only add commands you trust.</p>
               </div>
@@ -330,7 +339,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
               </button>
               <button
                 onClick={addCustom}
-                disabled={!draft.name.trim()}
+                disabled={!draft.name.trim() || (draft.quotaSource === 'command' && !draft.command.trim())}
                 className="flex-1 py-1.5 rounded-lg text-[11px] font-semibold bg-emerald-500 text-[#052e1c] disabled:opacity-40"
               >
                 Add

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -95,3 +95,26 @@ test('modelOrder keeps known ids, drops junk, and dedupes', () => {
   assert.deepEqual(result.modelOrder, ['grok', 'codex', 'custom_ok']);
   assert.deepEqual(config.sanitizeConfig({}).modelOrder, []);
 });
+
+test('migrates legacy custom CLI commands without mixing quota and activity commands', () => {
+  const result = config.sanitizeConfig({
+    customAgents: [
+      { id: 'custom_legacy', name: 'Legacy', quotaSource: 'unknown', command: 'aider' },
+      {
+        id: 'custom_command',
+        name: 'Command',
+        quotaSource: 'command',
+        command: 'node quota.js',
+        activityProcess: 'quota-agent.exe'
+      },
+      { id: 'custom_command_only', name: 'Command only', quotaSource: 'command', command: 'node quota.js' }
+    ]
+  });
+
+  assert.equal(result.customAgents[0].activityProcess, 'aider');
+  assert.equal(result.customAgents[0].command, 'aider');
+  assert.equal(result.customAgents[1].activityProcess, 'quota-agent.exe');
+  assert.equal(result.customAgents[1].command, 'node quota.js');
+  assert.equal(result.customAgents[2].activityProcess, '');
+  assert.equal(result.customAgents[2].command, 'node quota.js');
+});

--- a/tests/direct-activity.test.js
+++ b/tests/direct-activity.test.js
@@ -1,0 +1,101 @@
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const {
+  mergeActiveRings,
+  providerRoots,
+  readDirectAgentActivity
+} = require('../electron/direct_activity');
+
+function writeArtifact(filePath, mtimeMs) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '', 'utf8');
+  const stamp = new Date(mtimeMs);
+  fs.utimesSync(filePath, stamp, stamp);
+}
+
+test('detects multiple recent provider sessions from metadata only', (t) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notch-activity-'));
+  t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+  const now = Date.parse('2026-09-01T12:00:00.000Z');
+  writeArtifact(path.join(homeDir, '.codex', 'sessions', '2026', '09', '01', 'rollout-a.jsonl'), now - 1000);
+  writeArtifact(path.join(homeDir, '.grok', 'sessions', 'workspace', 'session', 'events.jsonl'), now - 2000);
+  writeArtifact(path.join(homeDir, '.cursor', 'projects', 'workspace', 'worker.log'), now - 3000);
+  writeArtifact(path.join(homeDir, '.claude', 'projects', 'workspace', 'old.jsonl'), now - 60_000);
+
+  const activity = readDirectAgentActivity({ homeDir, now, freshnessMs: 45_000 });
+  assert.deepEqual(activity.map((row) => row.activeRing), ['codex', 'cursor', 'grok']);
+  assert.ok(activity.every((row) => row.source === 'local-session'));
+  assert.ok(activity.every((row) => !Object.hasOwn(row, 'path')));
+});
+
+test('ignores unrelated and future-dated files', (t) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notch-activity-'));
+  t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+  const now = Date.parse('2026-09-01T12:00:00.000Z');
+  writeArtifact(path.join(homeDir, '.claude', 'projects', 'workspace', 'settings.json'), now - 1000);
+  writeArtifact(path.join(homeDir, '.claude', 'projects', 'workspace', 'tool-results', 'nested.jsonl'), now - 1000);
+  writeArtifact(path.join(homeDir, '.cursor', 'chats', 'workspace', 'session', 'store.db-wal'), now - 1000);
+  writeArtifact(path.join(homeDir, '.cursor', 'projects', 'workspace', 'agent-transcripts', 'session.jsonl'), now + 10_000);
+
+  assert.deepEqual(readDirectAgentActivity({ homeDir, now }), []);
+});
+
+test('detects both Gemini layouts and deduplicates the ring', (t) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notch-activity-'));
+  t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+  const now = Date.parse('2026-09-01T12:00:00.000Z');
+  writeArtifact(path.join(homeDir, '.gemini', 'antigravity', 'conversations', 'gui.db-wal'), now - 2000);
+  writeArtifact(path.join(homeDir, '.gemini', 'antigravity-cli', 'conversations', 'cli.db'), now - 1000);
+
+  const activity = readDirectAgentActivity({ homeDir, now, roots: providerRoots(homeDir) });
+  assert.deepEqual(activity.map((row) => row.activeRing), ['gemini']);
+});
+
+test('honors Codex and Claude home overrides', (t) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notch-activity-'));
+  t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+  const now = Date.parse('2026-09-01T12:00:00.000Z');
+  const codexHome = path.join(homeDir, 'custom-codex');
+  const claudeHome = path.join(homeDir, 'custom-claude');
+  writeArtifact(path.join(codexHome, 'sessions', '2026', '09', '01', 'rollout-now.jsonl'), now - 1000);
+  writeArtifact(path.join(claudeHome, 'projects', 'workspace', 'session.jsonl'), now - 1000);
+
+  const roots = providerRoots(homeDir, { CODEX_HOME: codexHome, CLAUDE_CONFIG_DIR: claudeHome }, now);
+  assert.deepEqual(readDirectAgentActivity({ homeDir, now, roots }).map((row) => row.activeRing), ['claude', 'codex']);
+});
+
+test('honors Grok and OpenCode data overrides', (t) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notch-activity-'));
+  t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+  const now = Date.parse('2026-09-01T12:00:00.000Z');
+  const grokHome = path.join(homeDir, 'custom-grok');
+  const xdgDataHome = path.join(homeDir, 'custom-data');
+  writeArtifact(path.join(grokHome, 'sessions', 'workspace', 'session', 'events.jsonl'), now - 1000);
+  writeArtifact(path.join(xdgDataHome, 'opencode', 'opencode.db-wal'), now - 1000);
+
+  const roots = providerRoots(homeDir, { GROK_HOME: grokHome, XDG_DATA_HOME: xdgDataHome }, now);
+  assert.deepEqual(readDirectAgentActivity({ homeDir, now, roots }).map((row) => row.activeRing), ['grok', 'opencode']);
+});
+
+test('can skip inactive provider trees after the process baseline', (t) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notch-activity-'));
+  t.after(() => fs.rmSync(homeDir, { recursive: true, force: true }));
+  const now = Date.parse('2026-09-01T12:00:00.000Z');
+  writeArtifact(path.join(homeDir, '.codex', 'sessions', '2026', '09', '01', 'rollout-now.jsonl'), now - 1000);
+  writeArtifact(path.join(homeDir, '.grok', 'sessions', 'workspace', 'session', 'events.jsonl'), now - 1000);
+
+  const activity = readDirectAgentActivity({ homeDir, now, includeRings: ['grok'] });
+  assert.deepEqual(activity.map((row) => row.activeRing), ['grok']);
+});
+
+test('merges direct sessions with the active MindSync ring', () => {
+  const rings = mergeActiveRings(
+    { jobStatus: 'running', activeRing: 'claude' },
+    [{ activeRing: 'codex' }, { activeRing: 'claude' }, { activeRing: 'grok' }]
+  );
+  assert.deepEqual(rings, ['claude', 'codex', 'grok']);
+});

--- a/tests/process-activity.test.js
+++ b/tests/process-activity.test.js
@@ -3,9 +3,12 @@ const test = require('node:test');
 
 const {
   ProcessActivityTracker,
+  activityExecutable,
+  customProcessMappings,
   parseUnixSamples,
   parseWindowsSamples,
-  ringForProcess
+  ringForProcess,
+  ringsForProcess
 } = require('../electron/process_activity');
 
 test('maps only dedicated CLI process names', () => {
@@ -15,6 +18,46 @@ test('maps only dedicated CLI process names', () => {
   assert.equal(ringForProcess('Cursor.exe'), null);
   assert.equal(ringForProcess('Antigravity.exe'), null);
   assert.equal(ringForProcess('node.exe'), null);
+});
+
+test('accepts only exact native executables for custom activity', () => {
+  assert.equal(activityExecutable('fixture-agent.exe'), 'fixture-agent');
+  assert.equal(activityExecutable('"C:\\Program Files\\Fixture\\fixture-agent.exe"'), 'fixture-agent');
+  assert.equal(activityExecutable('node --flag'), null);
+  assert.equal(activityExecutable('node.exe'), null);
+  assert.equal(activityExecutable('python3'), null);
+  assert.equal(activityExecutable('python3.12'), null);
+  assert.equal(activityExecutable('bun'), null);
+  assert.equal(activityExecutable('javaw.exe'), null);
+  assert.equal(activityExecutable('dotnet'), null);
+  assert.equal(activityExecutable('zsh'), null);
+  assert.equal(activityExecutable('fixture.ps1'), null);
+  assert.equal(activityExecutable(''), null);
+});
+
+test('maps one native process to every configured custom ring', () => {
+  const mappings = customProcessMappings([
+    { id: 'custom_a', activityProcess: 'fixture-agent' },
+    { id: 'custom_b', activityProcess: 'fixture-agent.exe' },
+    { id: 'custom_bad', activityProcess: 'node --flag' },
+    { id: 'not_custom', activityProcess: 'fixture-agent' }
+  ]);
+  assert.deepEqual({ ...mappings }, { 'fixture-agent': ['custom_a', 'custom_b'] });
+  assert.deepEqual(ringsForProcess('fixture-agent.exe', mappings), ['custom_a', 'custom_b']);
+  assert.deepEqual(ringsForProcess('codex.exe', { codex: ['custom_codex'] }), ['codex', 'custom_codex']);
+});
+
+test('treats prototype-like process names as inert data', () => {
+  const mappings = customProcessMappings([
+    { id: 'custom_constructor', activityProcess: 'constructor' },
+    { id: 'custom_proto', activityProcess: '__proto__' }
+  ]);
+  assert.deepEqual(Object.keys(mappings).sort(), ['__proto__', 'constructor']);
+  assert.deepEqual(mappings.constructor, ['custom_constructor']);
+  assert.deepEqual(mappings.__proto__, ['custom_proto']);
+  assert.deepEqual(ringsForProcess('constructor', mappings), ['custom_constructor']);
+  assert.deepEqual(ringsForProcess('__proto__', mappings), ['custom_proto']);
+  assert.deepEqual(ringsForProcess('constructor', {}), []);
 });
 
 test('parses process samples without command lines', () => {
@@ -61,4 +104,23 @@ test('keeps an idle live CLI glowing only for the grace window', async () => {
   assert.deepEqual(tracker.current().map((row) => row.activeRing), ['claude']);
   now += 2;
   assert.deepEqual(tracker.current(), []);
+});
+
+test('lights a custom ring from its configured native process', async () => {
+  const requestedNames = [];
+  const samples = [
+    [{ pid: 9, name: 'fixture-agent.exe', cpuSeconds: 4 }],
+    [{ pid: 9, name: 'fixture-agent.exe', cpuSeconds: 4.05 }]
+  ];
+  const tracker = new ProcessActivityTracker({
+    sampler: async (names) => {
+      requestedNames.push(names);
+      return samples.shift();
+    }
+  });
+  const mappings = { 'fixture-agent': ['custom_fixture'] };
+
+  assert.deepEqual(await tracker.sample(mappings), []);
+  assert.deepEqual((await tracker.sample(mappings)).map((row) => row.activeRing), ['custom_fixture']);
+  assert.deepEqual(requestedNames, [['fixture-agent'], ['fixture-agent']]);
 });

--- a/tests/process-activity.test.js
+++ b/tests/process-activity.test.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  ProcessActivityTracker,
+  parseUnixSamples,
+  parseWindowsSamples,
+  ringForProcess
+} = require('../electron/process_activity');
+
+test('maps only dedicated CLI process names', () => {
+  assert.equal(ringForProcess('codex.exe'), 'codex');
+  assert.equal(ringForProcess('/usr/bin/antigravity-cli'), 'gemini');
+  assert.equal(ringForProcess('cursor-agent.exe'), 'cursor');
+  assert.equal(ringForProcess('Cursor.exe'), null);
+  assert.equal(ringForProcess('Antigravity.exe'), null);
+  assert.equal(ringForProcess('node.exe'), null);
+});
+
+test('parses process samples without command lines', () => {
+  assert.deepEqual(parseWindowsSamples('[{"ProcessName":"codex","Id":42,"CPU":1.25}]'), [
+    { pid: 42, name: 'codex', cpuSeconds: 1.25 }
+  ]);
+  assert.deepEqual(parseUnixSamples(' 42 codex 01:02\n 43 grok 1:02:03\n 44 claude 1-02:03:04\n'), [
+    { pid: 42, name: 'codex', cpuSeconds: 62 },
+    { pid: 43, name: 'grok', cpuSeconds: 3723 },
+    { pid: 44, name: 'claude', cpuSeconds: 93784 }
+  ]);
+});
+
+test('lights every CPU-active CLI and clears exited processes', async () => {
+  let now = 1000;
+  const samples = [
+    [{ pid: 1, name: 'codex', cpuSeconds: 10 }, { pid: 2, name: 'grok', cpuSeconds: 20 }],
+    [{ pid: 1, name: 'codex', cpuSeconds: 10.02 }, { pid: 2, name: 'grok', cpuSeconds: 20.2 }],
+    [{ pid: 1, name: 'codex', cpuSeconds: 10.02 }]
+  ];
+  const tracker = new ProcessActivityTracker({ sampler: async () => samples.shift(), now: () => now, graceMs: 15_000 });
+
+  assert.deepEqual(await tracker.sample(), []);
+  assert.deepEqual(tracker.liveRings(), ['codex', 'grok']);
+  now += 3000;
+  assert.deepEqual((await tracker.sample()).map((row) => row.activeRing), ['codex', 'grok']);
+  now += 3000;
+  assert.deepEqual((await tracker.sample()).map((row) => row.activeRing), ['codex']);
+});
+
+test('keeps an idle live CLI glowing only for the grace window', async () => {
+  let now = 1000;
+  let cpu = 1;
+  const tracker = new ProcessActivityTracker({
+    sampler: async () => [{ pid: 7, name: 'claude', cpuSeconds: cpu }],
+    now: () => now,
+    graceMs: 10_000
+  });
+  await tracker.sample();
+  cpu += 0.02;
+  now += 1000;
+  await tracker.sample();
+  now += 9999;
+  assert.deepEqual(tracker.current().map((row) => row.activeRing), ['claude']);
+  now += 2;
+  assert.deepEqual(tracker.current(), []);
+});

--- a/tests/quota-state.test.js
+++ b/tests/quota-state.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { keepLastKnown, quotaFingerprint } = require('../electron/quota-state');
+const { activityFingerprint, keepLastKnown, quotaFingerprint } = require('../electron/quota-state');
 
 const start = Date.parse('2026-08-31T10:00:00.000Z');
 const known = {
@@ -53,4 +53,9 @@ test('expired auth bypasses stale last-known quota', () => {
   assert.equal(merged.models[0].authState, 'expired');
   assert.equal(merged.models[0].ringPercent, undefined);
   assert.equal(merged.models[0].stale, false);
+});
+
+test('activity fingerprints are stable for reordered rings and change with live agents', () => {
+  assert.equal(activityFingerprint(null, ['grok', 'codex']), activityFingerprint(null, ['codex', 'grok', 'codex']));
+  assert.notEqual(activityFingerprint(null, ['codex']), activityFingerprint(null, ['codex', 'grok']));
 });

--- a/tests/scrapers.test.js
+++ b/tests/scrapers.test.js
@@ -4,7 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { _test, getAllInstalledAgentUsage, saveLocalConfig } = require('../electron/scrapers');
+const { _test, getAllInstalledAgentUsage, probeCli, saveLocalConfig } = require('../electron/scrapers');
 
 test.beforeEach(() => _test.resetReaderCache());
 
@@ -218,4 +218,100 @@ test('disabled providers are filtered before any reader runs', async () => {
     delete process.env.NOTCH_LEGACY_CONFIG_PATH;
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('custom providers persist and render manual, command, and failure states', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-notch-custom-'));
+  const goodScript = path.join(root, 'quota-ok.js');
+  const badScript = path.join(root, 'quota-fail.js');
+  fs.writeFileSync(goodScript, "process.stdout.write(JSON.stringify({name:'Fixture Agent',sessionUsedPercent:74,weeklyUsedPercent:33,sessionResetText:'Session fixture',weeklyResetText:'Weekly fixture'}));\n", 'utf8');
+  fs.writeFileSync(badScript, 'process.exit(7);\n', 'utf8');
+  process.env.NOTCH_CONFIG_DIR = root;
+  process.env.NOTCH_LEGACY_CONFIG_PATH = path.join(root, 'missing-legacy.json');
+  try {
+    const quote = (value) => `"${String(value).replace(/"/g, '\\"')}"`;
+    const saved = saveLocalConfig({
+      enabledModels: {
+        codex: false,
+        claude: false,
+        gemini: false,
+        cursor: false,
+        opencode: false,
+        grok: false,
+        custom_manual: true,
+        custom_command: true,
+        custom_failure: true,
+        custom_disabled: false
+      },
+      alertThreshold: 80,
+      modelOrder: ['custom_command', 'custom_manual', 'custom_failure', 'custom_disabled'],
+      customAgents: [
+        {
+          id: 'custom_manual',
+          name: 'Manual Agent',
+          provider: 'Local',
+          quotaSource: 'manual',
+          activityProcess: 'fixture-agent',
+          sessionUsedPercent: 28,
+          weeklyUsedPercent: 61,
+          icon: 'spark'
+        },
+        {
+          id: 'custom_command',
+          name: 'Command Agent',
+          provider: 'Fixture',
+          quotaSource: 'command',
+          command: `${quote(process.execPath)} ${quote(goodScript)}`,
+          icon: 'codex'
+        },
+        {
+          id: 'custom_failure',
+          name: 'Broken Agent',
+          quotaSource: 'command',
+          command: `${quote(process.execPath)} ${quote(badScript)}`
+        },
+        {
+          id: 'custom_disabled',
+          name: 'Disabled Agent',
+          quotaSource: 'manual',
+          sessionUsedPercent: 99
+        }
+      ]
+    });
+    assert.equal(saved.customAgents.length, 4);
+    assert.equal(saved.customAgents.find((agent) => agent.id === 'custom_manual').activityProcess, 'fixture-agent');
+
+    const result = await getAllInstalledAgentUsage({ force: true, now: 10_000 });
+    assert.deepEqual(result.models.map((model) => model.id), ['custom_command', 'custom_manual', 'custom_failure']);
+    assert.equal(result.allDetectedIds.length, 10);
+
+    const command = result.models.find((model) => model.id === 'custom_command');
+    assert.equal(command.name, 'Fixture Agent');
+    assert.equal(command.ringPercent, 74);
+    assert.equal(command.quotaState, 'known');
+    assert.equal(command.sessionResetText, 'Session fixture');
+    assert.equal(command.weeklyResetText, 'Weekly fixture');
+
+    const manual = result.models.find((model) => model.id === 'custom_manual');
+    assert.equal(manual.ringPercent, 61);
+    assert.equal(manual.quotaState, 'known');
+
+    const failure = result.models.find((model) => model.id === 'custom_failure');
+    assert.equal(failure.quotaState, 'unknown');
+    assert.equal(failure.ringPercent, null);
+    assert.equal(failure.sessionResetText, 'Custom command failed');
+    assert.ok(fs.existsSync(path.join(root, 'config.json')));
+  } finally {
+    delete process.env.NOTCH_CONFIG_DIR;
+    delete process.env.NOTCH_LEGACY_CONFIG_PATH;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI probe accepts an executable name but rejects shell expressions', async () => {
+  const executable = process.platform === 'win32' ? 'node.exe' : 'node';
+  const found = await probeCli(executable);
+  assert.equal(found.found, true);
+  assert.ok(found.path);
+  assert.deepEqual(await probeCli('node --version'), { found: false, path: null });
 });


### PR DESCRIPTION
## Summary

- glow every directly active local provider ring, including simultaneous agents, while preserving MindSync handoff activity
- add privacy-safe process CPU/activity tracking without reading transcript contents
- validate custom providers end to end and separate their native activity process from optional JSON quota commands
- preserve legacy custom-provider config and fix quoted Windows quota commands
- add safe custom process mapping, generic-runtime rejection, persistence/reload coverage, and updated docs

## Custom provider behavior

Custom rings automatically glow when an exact native CLI process is configured and doing CPU work. Generic runtimes and wrapper scripts such as node, python, PowerShell, .cmd, and .ps1 are intentionally not inferred because they can light the wrong provider.

## Verification

- npm run check: 37/37 tests, logic smoke, production build
- npm run pack:check
- git diff --check
- real Playwright UI flow: PATH suggestion to add custom provider to persist separate activity/quota fields to live halo to reload
- independent correctness/security/concurrency re-review: no release-blocking findings
- live installed HUD left untouched

## PR interaction / merge order

Recommended integration order:

1. #5 Grok signed-in quota state
2. #9 Codex Team weekly-window classification, currently stacked on #5
3. #6 persisted last-known quota
4. #7 tucked threshold notification, currently stacked on #6
5. rebase this PR onto the integrated main, resolve the known narrow overlaps, rerun the full gate, then merge

This PR stays based on main so the glow/custom-provider feature remains independently reviewable. Its Codex-specific changes are compatible with #9, but #5 and #7 touch nearby tests, main-process, config, settings, and README surfaces. Landing #8 last keeps those integrations in one reviewed rebase instead of spreading conflict resolution across multiple smaller PRs.