### PR TITLE
Classify Codex Team weekly quota correctly

### DIFF
--- a/electron/scrapers.js
+++ b/electron/scrapers.js
@@ -382,6 +382,53 @@ function readCodexModelName() {
   return 'Codex';
 }
 
+const HOUR_SECONDS = 60 * 60;
+const DAY_SECONDS = 24 * HOUR_SECONDS;
+
+function codexWindowKind(window, fallbackKind) {
+  const seconds = Number(window && window.limit_window_seconds);
+  if (!Number.isFinite(seconds) || seconds <= 0) return fallbackKind;
+  return seconds <= DAY_SECONDS ? 'session' : 'weekly';
+}
+
+function codexWindowLabel(window, kind) {
+  const seconds = Number(window && window.limit_window_seconds);
+  if (!Number.isFinite(seconds) || seconds <= 0) return kind === 'weekly' ? 'Weekly' : '5h session';
+  if (kind === 'weekly') {
+    if (seconds >= 6 * DAY_SECONDS && seconds <= 8 * DAY_SECONDS) return 'Weekly';
+    if (seconds % DAY_SECONDS === 0) return `${seconds / DAY_SECONDS}d window`;
+    if (seconds % HOUR_SECONDS === 0) return `${seconds / HOUR_SECONDS}h window`;
+    return 'Plan window';
+  }
+  if (seconds % HOUR_SECONDS === 0) {
+    return `${seconds / HOUR_SECONDS}h session`;
+  }
+  if (seconds % 60 === 0) return `${seconds / 60}m session`;
+  return 'Session window';
+}
+
+function parseCodexWindows(rateLimit) {
+  const parsed = { session: null, weekly: null };
+  const windows = [
+    { value: rateLimit && rateLimit.primary_window, fallbackKind: 'session' },
+    { value: rateLimit && rateLimit.secondary_window, fallbackKind: 'weekly' }
+  ];
+  for (const entry of windows) {
+    const window = entry.value;
+    if (!window || typeof window !== 'object') continue;
+    const percent = coercePercent(window.used_percent ?? window.usage_percent);
+    if (percent == null) continue;
+    const kind = codexWindowKind(window, entry.fallbackKind);
+    const candidate = {
+      percent,
+      resetAt: window.reset_at,
+      label: codexWindowLabel(window, kind)
+    };
+    if (!parsed[kind] || candidate.percent > parsed[kind].percent) parsed[kind] = candidate;
+  }
+  return parsed;
+}
+
 async function getCodexUsage() {
   const dir = codexHome();
   const authPath = path.join(dir, 'auth.json');
@@ -444,10 +491,9 @@ async function getCodexUsage() {
     }
 
     const rateLimit = res.json.rate_limit || {};
-    const primary = rateLimit.primary_window || {};
-    const secondary = rateLimit.secondary_window || {};
-    const sessionUsed = coercePercent(primary.used_percent ?? primary.usage_percent);
-    const weeklyUsed = coercePercent(secondary.used_percent ?? secondary.usage_percent);
+    const { session, weekly } = parseCodexWindows(rateLimit);
+    const sessionUsed = session && session.percent;
+    const weeklyUsed = weekly && weekly.percent;
     const plan = res.json.plan_type ? String(res.json.plan_type).toUpperCase() : 'OpenAI';
 
     if (sessionUsed == null && weeklyUsed == null) {
@@ -471,10 +517,10 @@ async function getCodexUsage() {
       quotaState: 'known',
       sessionUsedPercent: sessionUsed,
       weeklyUsedPercent: weeklyUsed,
-      sessionLabel: '5h session',
-      weeklyLabel: 'Weekly',
-      sessionResetText: formatResetAt(primary.reset_at) || (sessionUsed == null ? 'No session window' : 'Active'),
-      weeklyResetText: formatResetAt(secondary.reset_at) || (weeklyUsed == null ? 'No weekly window' : 'Active')
+      sessionLabel: (session && session.label) || '5h session',
+      weeklyLabel: (weekly && weekly.label) || 'Weekly',
+      sessionResetText: formatResetAt(session && session.resetAt) || (sessionUsed == null ? 'No session window' : 'Active'),
+      weeklyResetText: formatResetAt(weekly && weekly.resetAt) || (weeklyUsed == null ? 'No weekly window' : 'Active')
     });
   } catch (err) {
     return detectedCard({
@@ -1405,6 +1451,7 @@ module.exports = {
     coercePercent,
     detectedCard,
     grokBillingCardFromResponse,
+    parseCodexWindows,
     quotaStatus,
     parseGrokBillingConfig,
     readWithCache,

--- a/tests/scrapers.test.js
+++ b/tests/scrapers.test.js
@@ -104,6 +104,67 @@ test('Grok accepted response stays signed in when percentage is not exposed', ()
   assert.equal(result.ringPercent, null);
 });
 
+test('Codex windows are classified by duration instead of response position', () => {
+  const result = _test.parseCodexWindows({
+    primary_window: {
+      used_percent: 50,
+      limit_window_seconds: 7 * 24 * 60 * 60,
+      reset_at: 1_800_000_000
+    },
+    secondary_window: null
+  });
+
+  assert.equal(result.session, null);
+  assert.deepEqual(result.weekly, {
+    percent: 50,
+    resetAt: 1_800_000_000,
+    label: 'Weekly'
+  });
+});
+
+test('Codex supports simultaneous and reversed 5h and weekly windows', () => {
+  const result = _test.parseCodexWindows({
+    primary_window: { used_percent: 61, limit_window_seconds: 7 * 24 * 60 * 60 },
+    secondary_window: { used_percent: 24, limit_window_seconds: 5 * 60 * 60 }
+  });
+
+  assert.equal(result.session.percent, 24);
+  assert.equal(result.session.label, '5h session');
+  assert.equal(result.weekly.percent, 61);
+  assert.equal(result.weekly.label, 'Weekly');
+});
+
+test('Codex keeps positional compatibility when duration metadata is absent', () => {
+  const result = _test.parseCodexWindows({
+    primary_window: { usage_percent: 12 },
+    secondary_window: { usage_percent: 34 }
+  });
+
+  assert.equal(result.session.percent, 12);
+  assert.equal(result.session.label, '5h session');
+  assert.equal(result.weekly.percent, 34);
+  assert.equal(result.weekly.label, 'Weekly');
+});
+
+test('Codex labels nonstandard multi-day limits as plan windows', () => {
+  const result = _test.parseCodexWindows({
+    primary_window: { used_percent: 9, limit_window_seconds: 2 * 24 * 60 * 60 }
+  });
+
+  assert.equal(result.session, null);
+  assert.equal(result.weekly.percent, 9);
+  assert.equal(result.weekly.label, '2d window');
+});
+
+test('Codex does not call a nonstandard short window 5h', () => {
+  const result = _test.parseCodexWindows({
+    primary_window: { used_percent: 4, limit_window_seconds: 90 * 60 }
+  });
+
+  assert.equal(result.session.label, '90m session');
+  assert.equal(result.weekly, null);
+});
+
 test('reader polling is single-flight and cached', async () => {
   let calls = 0;
   const entry = {


### PR DESCRIPTION
## Summary

- classify Codex quota windows from limit_window_seconds instead of assuming primary means 5h and secondary means weekly
- map the observed TEAM plan 604800-second primary window to Weekly, leaving the absent 5h row unknown
- preserve positional compatibility when older payloads omit duration metadata
- label nonstandard short and multi-day windows honestly instead of calling them 5h

## Reproduction

The signed-in TEAM payload currently returns one primary window with:

- used_percent around 50 percent
- limit_window_seconds 604800
- secondary_window null
- reset roughly six days away

Before this change Agent Notch labeled that primary window 5h. The fixed reader places it in weeklyUsedPercent and leaves sessionUsedPercent null.

Official Codex documentation describes five-hour usage windows and says additional weekly limits may apply:
https://developers.openai.com/codex/pricing

## Stacking

This PR is intentionally based on #5 because both provider fixes edit electron/scrapers.js and its tests. Merge #5 first; GitHub can then retarget this single Codex commit to main. The combined #5 plus #9 tree has been tested locally.

## Verification

- live sanitized TEAM reader: Weekly 53 percent, 5h unavailable, reset in about six days
- duration fixtures: 7-day-only, reversed 5h plus weekly, missing metadata, nonstandard 2-day and 90-minute windows
- combined #5 plus #9: 33/33 tests, logic smoke, production build
- npm run pack:check
- git diff --check
- independent review: no correctness, security, data-loss, or concurrency blockers