### PR TITLE
Prepare Agent Notch v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,26 @@
 
 All notable changes to Agent Notch are documented here.
 
-## [Unreleased]
+## [1.2.0] - 2026-09-01
 
 ### Added
 
 - Desktop toast when a quota crosses the critical threshold while the rail is tucked or hidden. Click the toast to reveal the HUD. Settings: **Notify when tucked**.
+- Direct activity glow for every active supported local CLI, including simultaneous agents and custom providers mapped to an exact native executable.
+
+### Changed
+
+- Last-known successful quota readings now survive restarts for up to 24 hours, remain visibly stale until refreshed, and are never replaced by unknown-only data.
+- Custom providers keep activity-process detection separate from optional JSON quota commands, with legacy config migration and reliable quoted Windows commands.
+
+### Fixed
+
+- Grok now distinguishes a valid signed-in session with unavailable quota from expired authentication and does not treat on-demand spend as included quota.
+- Codex quota windows are classified by their provider-reported duration, so personal 5-hour and weekly windows and Team weekly-only responses are labeled correctly regardless of response order.
+
+### Security
+
+- Persisted quota snapshots whitelist display-only fields; direct activity detection reads process and session metadata without reading prompts or transcripts.
 
 ## [1.1.0] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@
 
 - **Account-Level Quota Rings**: Periodically refreshed session and plan-window usage percentages at a single glance.
 - **Strictly Grounded Quotas**: Never estimates or shows fake percentages. Unknown or unauthenticated accounts display as `—` or `login`.
-- **Honest Failure State**: A failed refresh can retain the last successful value for up to five minutes, clearly marked with `~` and a stale notice, before returning to unknown.
+- **Honest Failure State**: Recent successful readings survive restarts for up to 24 hours and stay clearly marked with `~` and a stale notice until live data returns. Expired authentication is never masked by cached quota.
 - **Zero-Lag Click-Through**: Transparent overlay pixels automatically forward all mouse clicks, drags, and scrolls to background windows.
 - **100% Standalone & Local-First**: Works immediately out of the box using your local CLI credentials. Zero telemetry, zero external tracking servers.
-- **Custom Extensible**: Easily monitor custom CLI agents or scripts via stdout JSON commands or manual snapshots.
+- **Custom Extensible**: Monitor custom CLI agents through stdout JSON commands or manual snapshots, and optionally map an exact native executable for automatic activity glow.
 
 ---
 
@@ -53,11 +53,11 @@ Agent Notch detects and tracks live usage for major coding agent ecosystems dire
 
 | Provider / Ring | Monitored Windows | Data Source & Detection |
 | :--- | :--- | :--- |
-| **OpenAI Codex** | 5h Session + Weekly | ChatGPT WHAM usage endpoint (`~/.codex/auth.json`) |
+| **OpenAI Codex** | Provider-reported session + plan windows | ChatGPT WHAM usage endpoint (`~/.codex/auth.json`); windows are labeled by duration |
 | **Claude Code** | 5h Session + Weekly | Official Anthropic OAuth usage API (`~/.claude/.credentials.json`) |
 | **Gemini / Antigravity** | Quota Summary / Limits | Official Antigravity CLI token vault & Cloud Code usage API |
 | **Cursor** | Monthly Period Usage | Cursor IDE local state (`state.vscdb` / session token) |
-| **Grok CLI** | Session + Billing Credits | Grok CLI local configuration & billing endpoint |
+| **Grok CLI** | Included quota when exposed | Grok CLI local configuration & billing endpoint; signed-in unavailable usage stays explicit |
 | **OpenCode Go** | Go Subscription Usage | OpenCode Go plan quota (excludes BYOK local engines) |
 | **Custom CLIs** | Dynamic / Custom | Automatic PATH detection; JSON stdout reader or manual snapshot |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Right-edge HUD for live AI coding-agent quotas, plus a read-only view of MindSync job handoffs.
 
-**Status (2026-08-31):** Public at [adityarya24/agent-notch](https://github.com/adityarya24/agent-notch) (`v1.1.0`). Compact four-ring HUD, drag-reorder, in-rail collapse, quota-color glow. Mac / multi-monitor / packaged installer are demand-driven — see README Upcoming.
+**Status (2026-09-01):** Source prepared for `v1.2.0`; latest published release remains `v1.1.0` until the release is cut. Compact four-ring HUD, drag-reorder, in-rail collapse, quota-color glow, safe last-known quota, and tucked threshold notifications. Mac / multi-monitor / packaged installer are demand-driven — see README Upcoming.
 
 ---
 
@@ -20,13 +20,13 @@ Right-edge HUD for live AI coding-agent quotas, plus a read-only view of MindSyn
 
 Account-level live % where the vendor exposes it. Provider name on the ring. Unknown quota is a dash.
 
-- [x] OpenAI Codex — ChatGPT WHAM (5h + weekly).
+- [x] OpenAI Codex — ChatGPT WHAM, with provider-reported windows classified by duration.
 - [x] Claude Code — Anthropic OAuth usage.
 - [x] Cursor — IDE session token + dashboard period usage.
 - [x] Gemini / Antigravity — official CLI vault + quota summary.
-- [x] Grok CLI — billing credits.
+- [x] Grok CLI — included quota when the billing endpoint exposes it; honest signed-in unavailable state otherwise.
 - [x] OpenCode Go — Go plan only.
-- [x] Custom CLI — PATH detect; JSON command or manual snapshot, otherwise dash.
+- [x] Custom CLI — PATH detect; JSON command or manual snapshot, plus exact native-process activity mapping.
 
 Notch does **not** transfer jobs. It displays the latest MindSync handoff (`from → to`) from `~/.mindsync/dispatch/jobs/*/meta.json`.
 
@@ -36,7 +36,7 @@ Notch does **not** transfer jobs. It displays the latest MindSync handoff (`from
 
 MindSync dispatch has preemptive readers and headroom ranking. Notch stays a spectator — it does not transfer jobs.
 
-- [x] Active-agent glow in the ring’s own quota color (no pip).
+- [x] Active-agent glow in the ring’s own quota color for direct local sessions, simultaneous agents, custom native executables, and MindSync jobs (no pip).
 - [x] Four-ring viewport, scroll for extras, drag-to-reorder.
 - [x] One-shot handoff flash (`from → to (reason)`), 2–3s, no replay.
 - [x] Poll job `meta.json` every 2.5s while a job is running; quiet when none.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
## Summary

- bump package metadata from 1.1.0 to 1.2.0
- document direct multi-agent glow, tucked quota notifications, and safe last-known quota persistence
- clarify duration-based Codex windows, Grok unavailable-usage behavior, and custom-provider activity mapping
- align the roadmap with the integrated source and published-release boundary

## Verification

- npm run check (66/66 tests, logic smoke, production build)
- npm run pack:check
- git diff --check