### PR TITLE
Keep idle session-backed agents from glowing

### DIFF
--- a/electron/process_activity.js
+++ b/electron/process_activity.js
@@ -1,9 +1,8 @@
 const { execFile } = require('child_process');
 
 const PROCESS_GRACE_MS = 15 * 1000;
-// Interactive CLIs can spend a few dozen milliseconds on idle housekeeping
-// between samples. Keep that noise from continuously re-arming the glow.
-const MIN_CPU_DELTA_SECONDS = 0.1;
+const MIN_CPU_DELTA_SECONDS = 0.03;
+const MIN_ACTIVE_SAMPLES = 2;
 const BUILTIN_PROCESS_NAMES = ['codex', 'claude', 'grok', 'opencode', 'gemini', 'agy', 'antigravity-cli', 'cursor-agent'];
 const GENERIC_PROCESS_NAMES = new Set([
   'bash', 'bun', 'cmd', 'deno', 'dotnet', 'fish', 'java', 'javaw', 'perl', 'php',
@@ -59,6 +58,12 @@ function ringsForProcess(rawName, customMappings = {}) {
     && Array.isArray(customMappings[name]) ? customMappings[name] : [];
   for (const id of customRings) rings.add(id);
   return [...rings];
+}
+
+function supportsProcessOnlyActivity(ring) {
+  // Session-backed providers use their artifact writes as the work signal;
+  // their interactive processes can burn CPU indefinitely while idle.
+  return ring === 'codex' || /^custom_[A-Za-z0-9_-]+$/.test(String(ring || ''));
 }
 
 function cpuTimeSeconds(raw) {
@@ -127,13 +132,16 @@ class ProcessActivityTracker {
     sampler = sampleAgentProcesses,
     now = () => Date.now(),
     graceMs = PROCESS_GRACE_MS,
-    minCpuDeltaSeconds = MIN_CPU_DELTA_SECONDS
+    minCpuDeltaSeconds = MIN_CPU_DELTA_SECONDS,
+    minActiveSamples = MIN_ACTIVE_SAMPLES
   } = {}) {
     this.sampler = sampler;
     this.now = now;
     this.graceMs = graceMs;
     this.minCpuDeltaSeconds = minCpuDeltaSeconds;
+    this.minActiveSamples = minActiveSamples;
     this.previousCpu = new Map();
+    this.busyStreak = new Map();
     this.activeUntil = new Map();
     this.live = new Set();
     this.pending = null;
@@ -156,6 +164,7 @@ class ProcessActivityTracker {
     this.pending = Promise.resolve(this.sampler(Object.keys(customMappings))).then((samples) => {
       const now = this.now();
       const nextCpu = new Map();
+      const nextBusyStreak = new Map();
       const liveRings = new Set();
       for (const row of samples || []) {
         const rings = ringsForProcess(row.name, customMappings);
@@ -164,10 +173,16 @@ class ProcessActivityTracker {
           liveRings.add(ring);
           const key = `${ring}:${row.pid}`;
           const previous = this.previousCpu.get(key);
-          if (Number.isFinite(previous) && row.cpuSeconds - previous >= this.minCpuDeltaSeconds) {
+          const meaningfulDelta = Number.isFinite(previous)
+            && row.cpuSeconds - previous >= this.minCpuDeltaSeconds;
+          const streak = meaningfulDelta ? (this.busyStreak.get(key) || 0) + 1 : 0;
+          // Interactive CLIs can perform isolated housekeeping bursts while
+          // sitting at a prompt. Only sustained CPU movement represents work.
+          if (streak >= this.minActiveSamples && supportsProcessOnlyActivity(ring)) {
             this.activeUntil.set(ring, now + this.graceMs);
           }
           nextCpu.set(key, row.cpuSeconds);
+          nextBusyStreak.set(key, streak);
         }
       }
       for (const ring of this.activeUntil.keys()) {
@@ -175,6 +190,7 @@ class ProcessActivityTracker {
       }
       this.live = liveRings;
       this.previousCpu = nextCpu;
+      this.busyStreak = nextBusyStreak;
       return this.current();
     }).catch(() => this.current()).finally(() => {
       this.pending = null;
@@ -185,6 +201,7 @@ class ProcessActivityTracker {
 
 module.exports = {
   BUILTIN_PROCESS_NAMES,
+  MIN_ACTIVE_SAMPLES,
   MIN_CPU_DELTA_SECONDS,
   PROCESS_GRACE_MS,
   ProcessActivityTracker,
@@ -196,5 +213,6 @@ module.exports = {
   parseWindowsSamples,
   ringForProcess,
   ringsForProcess,
-  sampleAgentProcesses
+  sampleAgentProcesses,
+  supportsProcessOnlyActivity
 };

--- a/tests/process-activity.test.js
+++ b/tests/process-activity.test.js
@@ -8,7 +8,8 @@ const {
   parseUnixSamples,
   parseWindowsSamples,
   ringForProcess,
-  ringsForProcess
+  ringsForProcess,
+  supportsProcessOnlyActivity
 } = require('../electron/process_activity');
 
 test('maps only dedicated CLI process names', () => {
@@ -47,6 +48,16 @@ test('maps one native process to every configured custom ring', () => {
   assert.deepEqual(ringsForProcess('codex.exe', { codex: ['custom_codex'] }), ['codex', 'custom_codex']);
 });
 
+test('uses CPU-only glow only where no reliable session signal is available', () => {
+  assert.equal(supportsProcessOnlyActivity('codex'), true);
+  assert.equal(supportsProcessOnlyActivity('custom_fixture'), true);
+  assert.equal(supportsProcessOnlyActivity('grok'), false);
+  assert.equal(supportsProcessOnlyActivity('claude'), false);
+  assert.equal(supportsProcessOnlyActivity('gemini'), false);
+  assert.equal(supportsProcessOnlyActivity('cursor'), false);
+  assert.equal(supportsProcessOnlyActivity('opencode'), false);
+});
+
 test('treats prototype-like process names as inert data', () => {
   const mappings = customProcessMappings([
     { id: 'custom_constructor', activityProcess: 'constructor' },
@@ -71,24 +82,27 @@ test('parses process samples without command lines', () => {
   ]);
 });
 
-test('lights every CPU-active CLI and clears exited processes', async () => {
+test('lights CPU-backed rings but leaves session-backed providers to artifact activity', async () => {
   let now = 1000;
   const samples = [
     [{ pid: 1, name: 'codex', cpuSeconds: 10 }, { pid: 2, name: 'grok', cpuSeconds: 20 }],
-    [{ pid: 1, name: 'codex', cpuSeconds: 10.12 }, { pid: 2, name: 'grok', cpuSeconds: 20.2 }],
-    [{ pid: 1, name: 'codex', cpuSeconds: 10.12 }]
+    [{ pid: 1, name: 'codex', cpuSeconds: 10.08 }, { pid: 2, name: 'grok', cpuSeconds: 20.08 }],
+    [{ pid: 1, name: 'codex', cpuSeconds: 10.16 }, { pid: 2, name: 'grok', cpuSeconds: 20.16 }],
+    [{ pid: 1, name: 'codex', cpuSeconds: 10.16 }]
   ];
   const tracker = new ProcessActivityTracker({ sampler: async () => samples.shift(), now: () => now, graceMs: 15_000 });
 
   assert.deepEqual(await tracker.sample(), []);
   assert.deepEqual(tracker.liveRings(), ['codex', 'grok']);
   now += 3000;
-  assert.deepEqual((await tracker.sample()).map((row) => row.activeRing), ['codex', 'grok']);
+  assert.deepEqual(await tracker.sample(), []);
+  now += 3000;
+  assert.deepEqual((await tracker.sample()).map((row) => row.activeRing), ['codex']);
   now += 3000;
   assert.deepEqual((await tracker.sample()).map((row) => row.activeRing), ['codex']);
 });
 
-test('does not light an open idle CLI from background CPU jitter', async () => {
+test('does not light an open Grok prompt from sustained background CPU', async () => {
   let now = 1000;
   let cpu = 10;
   const tracker = new ProcessActivityTracker({
@@ -97,7 +111,7 @@ test('does not light an open idle CLI from background CPU jitter', async () => {
   });
 
   assert.deepEqual(await tracker.sample(), []);
-  for (const delta of [0.01, 0.05, 0.02, 0.09]) {
+  for (const delta of [0.12, 0.12, 0.12, 0.12]) {
     cpu += delta;
     now += 3000;
     assert.deepEqual(await tracker.sample(), []);
@@ -109,16 +123,20 @@ test('keeps an idle live CLI glowing only for the grace window', async () => {
   let now = 1000;
   let cpu = 1;
   const tracker = new ProcessActivityTracker({
-    sampler: async () => [{ pid: 7, name: 'claude', cpuSeconds: cpu }],
+    sampler: async () => [{ pid: 7, name: 'codex', cpuSeconds: cpu }],
     now: () => now,
     graceMs: 10_000
   });
   await tracker.sample();
-  cpu += 0.12;
+  cpu += 0.08;
+  now += 1000;
+  await tracker.sample();
+  assert.deepEqual(tracker.current(), []);
+  cpu += 0.08;
   now += 1000;
   await tracker.sample();
   now += 9999;
-  assert.deepEqual(tracker.current().map((row) => row.activeRing), ['claude']);
+  assert.deepEqual(tracker.current().map((row) => row.activeRing), ['codex']);
   now += 2;
   assert.deepEqual(tracker.current(), []);
 });
@@ -127,7 +145,8 @@ test('lights a custom ring from its configured native process', async () => {
   const requestedNames = [];
   const samples = [
     [{ pid: 9, name: 'fixture-agent.exe', cpuSeconds: 4 }],
-    [{ pid: 9, name: 'fixture-agent.exe', cpuSeconds: 4.12 }]
+    [{ pid: 9, name: 'fixture-agent.exe', cpuSeconds: 4.08 }],
+    [{ pid: 9, name: 'fixture-agent.exe', cpuSeconds: 4.16 }]
   ];
   const tracker = new ProcessActivityTracker({
     sampler: async (names) => {
@@ -138,6 +157,7 @@ test('lights a custom ring from its configured native process', async () => {
   const mappings = { 'fixture-agent': ['custom_fixture'] };
 
   assert.deepEqual(await tracker.sample(mappings), []);
+  assert.deepEqual(await tracker.sample(mappings), []);
   assert.deepEqual((await tracker.sample(mappings)).map((row) => row.activeRing), ['custom_fixture']);
-  assert.deepEqual(requestedNames, [['fixture-agent'], ['fixture-agent']]);
+  assert.deepEqual(requestedNames, [['fixture-agent'], ['fixture-agent'], ['fixture-agent']]);
 });


### PR DESCRIPTION
## Summary

- stop treating CPU alone as work for session-backed providers whose interactive processes can stay busy at an idle prompt
- keep Grok, Claude, Gemini, Cursor, and OpenCode glow tied to recent privacy-safe session or database writes
- retain sustained CPU fallback for Codex compatibility and exact native custom providers
- require two consecutive meaningful CPU samples for that fallback so isolated housekeeping bursts cannot arm glow

## Why PR #12 was insufficient

A later live idle Grok burst crossed the raised single-sample threshold and re-armed the 15-second grace window. Issue #11 was reopened rather than claiming that threshold-only mitigation fixed the behavior.

## Verification

- live 8-sample run: working Codex active, idle Grok never active
- focused process and direct-activity tests: 17/17
- npm run check: 68/68 tests, logic smoke, production build
- npm run pack:check
- git diff --check

Fixes #11