### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [1.2.1] - 2026-09-01
+
+### Fixed
+
+- Open but idle Claude, Gemini, Grok, Cursor, and OpenCode sessions no longer keep the activity ring glowing; session-backed providers now require a recent trustworthy work signal, while CPU fallback providers require sustained activity.
+
 ## [1.2.0] - 2026-09-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bump Agent Notch to v1.2.1
- document the idle-session glow hotfix already merged on main

## Verification
- npm run check
- npm run pack:check