### PR TITLE
feat: add provider self-registration and known-app discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,41 @@ Manage Agent Notch from any terminal via the `notch` command:
 | `notch disable-startup` | Remove Agent Notch from Windows Startup |
 | `notch smoke` | Run an end-to-end glow & handoff demo on the live HUD (0 quota burn) |
 | `notch smoke --clear` | Clean up leftover test artifacts from smoke runs |
+| `notch provider ...` | Register, list, remove, or discover custom providers |
 | `notch help` | Display available CLI commands |
 
 > [!NOTE]
 > **Hotkey**: Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd> to toggle HUD visibility while running. (Note: Hotkey toggles visibility of the active instance; if the process is stopped via `notch stop`, launch it again using `notch`).
+
+### Provider registration from an agent
+
+An agent can opt itself into Notch without editing JSON. The command is
+non-interactive and writes the existing per-user config atomically:
+
+```bash
+notch provider add zcode --name "ZCode" --process ZCode.exe --quota none --icon auto
+```
+
+`register` is an alias for `add`. The exact native executable name is required
+for the activity glow; generic runtimes (`node`, `python`, PowerShell) and shell
+wrappers are rejected. Quota can be `none`, `manual`, or `command` (the latter
+uses a trusted local command that prints the JSON shape documented below).
+
+```bash
+notch provider list
+notch provider remove custom_zcode
+notch provider discover
+notch provider discover --json
+```
+
+`discover` and the Settings suggestions are detection-only: they never add a
+provider silently. Known desktop apps such as ZCode can be suggested from a
+cataloged Windows install path or native process even when they are not on PATH;
+click the suggestion in Settings or run `provider add` to opt in. Unknown tools
+must be registered once by the agent/user with the command above. `--icon auto`
+selects a deliberate bundled icon for known providers (ZCode uses the Cursor
+icon) and falls back to the generic Spark icon for unknown providers; Notch does
+not extract arbitrary executable icons.
 
 ---
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,7 +38,12 @@ function resolveElectron() {
   return win;
 }
 
-const electronPath = resolveElectron();
+let cachedElectronPath = null;
+
+function getElectronPath() {
+  if (!cachedElectronPath) cachedElectronPath = resolveElectron();
+  return cachedElectronPath;
+}
 
 function readLegacyPid() {
   try {
@@ -124,6 +129,7 @@ function sleep(ms) {
 }
 
 function spawnElectron() {
+  const electronPath = getElectronPath();
   if (!fs.existsSync(electronPath)) {
     throw new Error(`Electron binary missing at ${electronPath}. From the repo run: npm install`);
   }
@@ -211,6 +217,7 @@ function vbsQuote(value) {
 
 function enableAutostart() {
   try {
+    const electronPath = getElectronPath();
     const startupVbs = startupVbsPath();
     const vbs = [
       'Set WshShell = CreateObject("WScript.Shell")',

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,12 @@ const {
   readPid: readRuntimePid,
   clearPid: clearRuntimePid
 } = require('../electron/runtime-state');
+const {
+  discoverProviders,
+  listProviders,
+  registerProvider,
+  removeProvider
+} = require('../electron/provider-registry');
 
 const rootDir = path.resolve(__dirname, '..');
 const distIndex = path.join(rootDir, 'dist', 'index.html');
@@ -230,6 +236,150 @@ function disableAutostart() {
   } catch (e) {}
 }
 
+function parseProviderOptions(tokens) {
+  const positionals = [];
+  const options = {};
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = String(tokens[i] || '');
+    if (!token.startsWith('--')) {
+      positionals.push(token);
+      continue;
+    }
+    const raw = token.slice(2);
+    const equals = raw.indexOf('=');
+    const key = (equals >= 0 ? raw.slice(0, equals) : raw).trim();
+    if (!key) continue;
+    if (equals >= 0) {
+      options[key] = raw.slice(equals + 1);
+      continue;
+    }
+    const next = tokens[i + 1];
+    if (next != null && !String(next).startsWith('--')) {
+      options[key] = String(next);
+      i += 1;
+    } else {
+      options[key] = true;
+    }
+  }
+  return { positionals, options };
+}
+
+function providerJsonRequested(options) {
+  return options.json === true || String(options.json || '').toLowerCase() === 'true';
+}
+
+function providerHelp() {
+  console.log(`Provider commands (local config only):
+  notch provider add <id> --name "Name" --process Agent.exe [options]
+  notch provider register <id> --name "Name" --process Agent.exe [options]
+  notch provider list [--json]
+  notch provider remove <id-or-name> [--json]
+  notch provider discover [--json]
+
+Add/register options:
+  --quota none|manual|command    Default: none (stored as unknown quota)
+  --session <0-100>              Manual session usage percent
+  --weekly <0-100>               Manual weekly usage percent
+  --command "..."                Trusted local command that prints quota JSON
+  --provider "..."               Provider label shown in the HUD
+  --icon auto|spark|claude|codex|gemini|cursor|grok|opencode
+
+Discovery only returns suggestions. It never edits config. Known apps such as
+ZCode can be found from a cataloged install path or running native process even
+when no zcode command is on PATH. Use Settings or add/register to opt in.
+Activity processes must be exact native executable names; generic runtimes and
+shell wrappers are rejected.
+`);
+}
+
+function printProviderList(providers, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(providers, null, 2));
+    return;
+  }
+  if (!providers.length) {
+    console.log('No custom providers registered.');
+    return;
+  }
+  for (const provider of providers) {
+    const quota = provider.quotaSource === 'unknown' ? 'none' : provider.quotaSource;
+    console.log(`${provider.id}\t${provider.name}\tprocess=${provider.activityProcess}\tquota=${quota}\ticon=${provider.icon}`);
+  }
+}
+
+function printProviderDiscovery(suggestions, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(suggestions, null, 2));
+    return;
+  }
+  if (!suggestions.length) {
+    console.log('No cataloged providers detected.');
+    return;
+  }
+  console.log('Detected providers (suggestions only; config unchanged):');
+  for (const item of suggestions) {
+    const evidence = item.evidence || 'detected';
+    const location = item.path || item.process || item.app || item.command;
+    console.log(`  ${item.name} — ${evidence}${location ? ` (${location})` : ''}; add with Settings or notch provider add`);
+  }
+}
+
+async function runProviderCommand(providerArgs) {
+  const subcommand = String(providerArgs[0] || 'help').toLowerCase();
+  const parsed = parseProviderOptions(providerArgs.slice(1));
+  const { positionals, options } = parsed;
+  const asJson = providerJsonRequested(options);
+  if (subcommand === 'help' || options.help) {
+    providerHelp();
+    return;
+  }
+
+  if (subcommand === 'add' || subcommand === 'register') {
+    const result = registerProvider({
+      id: options.id || positionals[0],
+      name: options.name || options.displayName,
+      provider: options.provider,
+      activityProcess: options.process || options['activity-process'],
+      quota: options.quota || options['quota-source'],
+      quotaCommand: options.command || options['quota-command'],
+      session: options.session,
+      weekly: options.weekly,
+      icon: options.icon || 'auto',
+      modelName: options.model
+    });
+    if (asJson) {
+      console.log(JSON.stringify({ ...result, created: result.created }, null, 2));
+    } else {
+      const quota = result.agent.quotaSource === 'unknown' ? 'none' : result.agent.quotaSource;
+      console.log(`Provider ${result.created ? 'registered' : 'updated'}: ${result.agent.name} (${result.agent.id})`);
+      console.log(`  process: ${result.agent.activityProcess}`);
+      console.log(`  quota:   ${quota}`);
+      console.log(`  icon:    ${result.agent.icon}`);
+    }
+    return;
+  }
+
+  if (subcommand === 'list') {
+    printProviderList(listProviders(), asJson);
+    return;
+  }
+
+  if (subcommand === 'remove' || subcommand === 'rm') {
+    const selector = options.id || options.name || positionals[0];
+    const result = removeProvider(selector);
+    if (asJson) console.log(JSON.stringify(result.removed, null, 2));
+    else console.log(`Removed custom provider: ${result.removed.name} (${result.removed.id})`);
+    return;
+  }
+
+  if (subcommand === 'discover' || subcommand === 'detect') {
+    printProviderDiscovery(await discoverProviders(), asJson);
+    return;
+  }
+
+  throw new Error(`Unknown provider command: ${subcommand}`);
+}
+
 function printHelp() {
   console.log(`Agent Notch — right-edge AI quota HUD
 
@@ -247,6 +397,7 @@ Commands:
   notch disable-startup Remove logon launch
   notch smoke           Glow demo on the live HUD (no quota burn)
   notch smoke --clear   Remove leftover smoke jobs
+  notch provider help   Register, list, remove, or discover custom providers
   notch help            This text
 
 Hotkey Ctrl+Shift+U only works while Notch is running (hide/show).
@@ -292,6 +443,12 @@ switch (command) {
     break;
   case 'smoke':
     runSmoke();
+    break;
+  case 'provider':
+    runProviderCommand(args.slice(1)).catch((err) => {
+      console.error(`Provider command failed: ${err.message || err}`);
+      process.exitCode = 1;
+    });
     break;
   case 'help':
   case '--help':

--- a/electron/config.js
+++ b/electron/config.js
@@ -140,6 +140,8 @@ function saveLocalConfig(value) {
 module.exports = {
   BUILTIN_IDS,
   DEFAULT_CONFIG,
+  ICONS,
+  QUOTA_SOURCES,
   appDataRoot,
   configPath,
   getLocalConfig,

--- a/electron/provider-registry.js
+++ b/electron/provider-registry.js
@@ -1,0 +1,420 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFile } = require('child_process');
+const { ICONS, getLocalConfig, sanitizeConfig, saveLocalConfig } = require('./config');
+const { activityExecutable, normalizeProcessName } = require('./process_activity');
+
+const DEFAULT_ICON = 'spark';
+const WINDOWS = 'win32';
+
+// This catalog is deliberately small and explicit. It is the shared source for
+// CLI discovery, Settings suggestions, and --icon auto resolution. Unknown
+// providers always use the bundled Spark icon; Notch never reads arbitrary
+// executable icons from disk.
+const PROVIDER_CATALOG = Object.freeze([
+  { id: 'aider', name: 'Aider', provider: 'Custom', command: 'aider', activityProcess: 'aider', icon: 'spark' },
+  { id: 'copilot', name: 'GitHub Copilot', provider: 'GitHub', command: 'copilot', activityProcess: 'copilot', icon: 'codex' },
+  { id: 'amp', name: 'Amp', provider: 'Sourcegraph', command: 'amp', activityProcess: 'amp', icon: 'spark' },
+  { id: 'goose', name: 'Goose', provider: 'Block', command: 'goose', activityProcess: 'goose', icon: 'spark' },
+  { id: 'crush', name: 'Crush', provider: 'Charm', command: 'crush', activityProcess: 'crush', icon: 'spark' },
+  { id: 'qwen', name: 'Qwen', provider: 'Alibaba', command: 'qwen', activityProcess: 'qwen', icon: 'spark' },
+  {
+    id: 'zcode',
+    name: 'ZCode',
+    provider: 'Zhipu AI · ZCode',
+    command: 'zcode',
+    activityProcess: 'ZCode.exe',
+    // ZCode is an IDE-like desktop agent, so Cursor is the deliberate bundled
+    // visual. This is a catalog choice, not executable icon extraction.
+    icon: 'cursor',
+    aliases: ['z-code', 'zhipu', 'zhipuai'],
+    windowsPaths: zcodeWindowsPaths,
+    nativeAppIds: ['dev.zcode.app'],
+    nativeAppNames: ['ZCode']
+  }
+]);
+
+const BUILTIN_ICON_ALIASES = Object.freeze({
+  codex: 'codex',
+  openai: 'codex',
+  claude: 'claude',
+  'claude-code': 'claude',
+  anthropic: 'claude',
+  gemini: 'gemini',
+  antigravity: 'gemini',
+  cursor: 'cursor',
+  opencode: 'opencode',
+  grok: 'grok',
+  xai: 'grok'
+});
+
+function text(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function normalizedKey(value) {
+  return text(value).toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function envValue(env, ...keys) {
+  for (const key of keys) {
+    const value = text(env && env[key]);
+    if (value) return value;
+  }
+  return '';
+}
+
+function zcodeWindowsPaths(env = process.env, homeDir = os.homedir()) {
+  const localAppData = envValue(env, 'LOCALAPPDATA', 'LocalAppData')
+    || path.join(homeDir, 'AppData', 'Local');
+  const programFiles = envValue(env, 'ProgramFiles', 'PROGRAMFILES');
+  const programFilesX86 = envValue(env, 'ProgramFiles(x86)', 'PROGRAMFILES(X86)');
+  return [
+    path.join(localAppData, 'Programs', 'ZCode', 'ZCode.exe'),
+    path.join(localAppData, 'Programs', 'ZhipuAI', 'ZCode', 'ZCode.exe'),
+    path.join(localAppData, 'ZCode', 'ZCode.exe'),
+    programFiles && path.join(programFiles, 'ZCode', 'ZCode.exe'),
+    programFiles && path.join(programFiles, 'ZhipuAI', 'ZCode', 'ZCode.exe'),
+    programFilesX86 && path.join(programFilesX86, 'ZCode', 'ZCode.exe')
+  ].filter(Boolean);
+}
+
+function catalogEntries() {
+  return PROVIDER_CATALOG.map((entry) => ({ ...entry }));
+}
+
+function findCatalogEntry(...values) {
+  const keys = values.flatMap((value) => {
+    const raw = text(value);
+    return raw ? [normalizedKey(raw), raw.toLowerCase()] : [];
+  }).filter(Boolean);
+  return PROVIDER_CATALOG.find((entry) => {
+    const aliases = [entry.id, entry.name, entry.provider, entry.command, entry.activityProcess, ...(entry.aliases || [])];
+    return aliases.some((alias) => {
+      const raw = text(alias);
+      return keys.includes(normalizedKey(raw)) || keys.includes(raw.toLowerCase());
+    });
+  }) || null;
+}
+
+function iconForProvider(...values) {
+  const entry = findCatalogEntry(...values);
+  if (entry && ICONS.has(entry.icon)) return entry.icon;
+  for (const value of values) {
+    const raw = text(value).toLowerCase();
+    if (BUILTIN_ICON_ALIASES[raw] && ICONS.has(BUILTIN_ICON_ALIASES[raw])) {
+      return BUILTIN_ICON_ALIASES[raw];
+    }
+  }
+  return DEFAULT_ICON;
+}
+
+function resolveIcon(value, ...providerValues) {
+  const requested = text(value).toLowerCase();
+  if (!requested || requested === 'auto') return iconForProvider(...providerValues);
+  if (!ICONS.has(requested)) {
+    throw new Error(`Unknown icon "${requested}". Use auto or a bundled icon.`);
+  }
+  return requested;
+}
+
+function canonicalId(value, name) {
+  const supplied = text(value);
+  if (supplied) {
+    const id = supplied.startsWith('custom_') ? supplied : `custom_${supplied}`;
+    if (!/^custom_[A-Za-z0-9_-]{1,80}$/.test(id)) {
+      throw new Error('Provider id must contain only letters, numbers, _ and -');
+    }
+    return id;
+  }
+  const slug = text(name).toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '_')
+    .replace(/^[_-]+|[_-]+$/g, '')
+    .slice(0, 72);
+  if (!slug) throw new Error('Display name is required');
+  return `custom_${slug}`;
+}
+
+function canonicalActivityProcess(value) {
+  const raw = text(value);
+  if (raw.includes('\0')) throw new Error('Activity process contains an invalid character');
+  if (!raw) throw new Error('Exact native activity process is required (for example: ZCode.exe)');
+  if (raw.length > 80 || /[\s/\\]/.test(raw)) {
+    throw new Error('Activity process must be an exact executable name, without spaces or a path');
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(raw) || /\.(?:bat|cmd|ps1|sh)$/i.test(raw)) {
+    throw new Error('Activity process must be a native executable name, not a shell wrapper');
+  }
+  if (!activityExecutable(raw)) {
+    throw new Error('Activity process must not be a generic runtime such as node, python, or PowerShell');
+  }
+  return raw;
+}
+
+function parsePercent(value, label) {
+  if (value === '' || value == null) return null;
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0 || number > 100) {
+    throw new Error(`${label} must be a number from 0 to 100`);
+  }
+  return Math.round(number);
+}
+
+function quotaSource(value) {
+  const source = text(value || 'none').toLowerCase();
+  if (source === 'none' || source === 'unknown') return 'unknown';
+  if (source === 'manual' || source === 'command') return source;
+  throw new Error('Quota mode must be none, manual, or command');
+}
+
+function buildProvider(input = {}) {
+  if (!input || typeof input !== 'object') throw new Error('Provider details are required');
+  const name = text(input.name || input.displayName);
+  if (!name) throw new Error('Display name is required');
+  if (name.length > 80) throw new Error('Display name must be 80 characters or fewer');
+  const activityProcess = canonicalActivityProcess(input.activityProcess || input.process);
+  const entry = findCatalogEntry(input.id, input.providerId, name, input.provider, input.command, activityProcess);
+  const source = quotaSource(input.quotaSource || input.quota);
+  const command = text(input.quotaCommand || input.command);
+  const session = parsePercent(input.sessionUsedPercent ?? input.session, 'Session percent');
+  const weekly = parsePercent(input.weeklyUsedPercent ?? input.weekly, 'Weekly percent');
+  if (source === 'command' && !command) {
+    throw new Error('Quota command is required when quota mode is command');
+  }
+  if (source === 'manual' && session == null && weekly == null) {
+    throw new Error('At least one session or weekly percent is required for manual quota');
+  }
+  return {
+    id: canonicalId(input.id || input.providerId, name),
+    name,
+    modelName: text(input.modelName).slice(0, 80),
+    provider: text(input.provider || (entry && entry.provider) || 'Custom').slice(0, 80) || 'Custom',
+    icon: resolveIcon(input.icon || 'auto', input.id, input.providerId, name, input.provider, input.command, activityProcess),
+    quotaSource: source,
+    sessionUsedPercent: session,
+    weeklyUsedPercent: weekly,
+    sessionResetText: text(input.sessionResetText),
+    weeklyResetText: text(input.weeklyResetText),
+    activityProcess,
+    command: source === 'command' ? command : ''
+  };
+}
+
+function registerProvider(input, options = {}) {
+  const current = sanitizeConfig(options.config || getLocalConfig());
+  const agent = buildProvider(input);
+  const customAgents = current.customAgents.filter((item) => item.id !== agent.id);
+  const enabledModels = { ...current.enabledModels, [agent.id]: true };
+  const next = (options.save || saveLocalConfig)({
+    ...current,
+    enabledModels,
+    customAgents: [...customAgents, agent]
+  });
+  return {
+    agent: next.customAgents.find((item) => item.id === agent.id) || agent,
+    created: !current.customAgents.some((item) => item.id === agent.id),
+    config: next
+  };
+}
+
+function removeProvider(selector, options = {}) {
+  const needle = text(selector).toLowerCase();
+  if (!needle) throw new Error('Provider id or display name is required');
+  const current = sanitizeConfig(options.config || getLocalConfig());
+  const match = current.customAgents.find((item) => (
+    item.id.toLowerCase() === needle || item.name.toLowerCase() === needle
+  ));
+  if (!match) throw new Error(`Custom provider not found: ${selector}`);
+  const enabledModels = { ...current.enabledModels };
+  delete enabledModels[match.id];
+  const next = (options.save || saveLocalConfig)({
+    ...current,
+    enabledModels,
+    customAgents: current.customAgents.filter((item) => item.id !== match.id)
+  });
+  return { removed: match, config: next };
+}
+
+function listProviders(config = getLocalConfig()) {
+  return sanitizeConfig(config).customAgents.map((agent) => ({ ...agent }));
+}
+
+function exists(fileSystem, filePath) {
+  try {
+    return Boolean(fileSystem.existsSync(filePath));
+  } catch (e) {
+    return false;
+  }
+}
+
+function processToken(value) {
+  return normalizeProcessName(text(value));
+}
+
+function matchingProcess(entry, runningProcesses) {
+  const expected = processToken(entry.activityProcess);
+  for (const item of runningProcesses || []) {
+    const value = item && typeof item === 'object'
+      ? (item.name || item.ProcessName || item.path || item.ImageName)
+      : item;
+    if (processToken(value) === expected) return text(value) || entry.activityProcess;
+  }
+  return null;
+}
+
+function matchingNativeApp(entry, nativeApps) {
+  const ids = new Set((entry.nativeAppIds || []).map(normalizedKey));
+  const names = new Set((entry.nativeAppNames || []).map(normalizedKey));
+  for (const item of nativeApps || []) {
+    const value = item && typeof item === 'object'
+      ? [item.id, item.appId, item.name, item.displayName, item.packageName]
+      : [item];
+    if (value.some((part) => ids.has(normalizedKey(part)) || names.has(normalizedKey(part)))) {
+      return text(value.find((part) => part));
+    }
+  }
+  return null;
+}
+
+function readRunningProcesses() {
+  return new Promise((resolve) => {
+    if (process.platform !== WINDOWS) {
+      resolve([]);
+      return;
+    }
+    const command = 'Get-Process -ErrorAction SilentlyContinue | Select-Object -ExpandProperty ProcessName | ConvertTo-Json -Compress';
+    execFile('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command], {
+      timeout: 3000,
+      windowsHide: true,
+      maxBuffer: 128 * 1024
+    }, (error, stdout) => {
+      if (error || !stdout) {
+        resolve([]);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(String(stdout).trim());
+        resolve(Array.isArray(parsed) ? parsed : [parsed]);
+      } catch (e) {
+        resolve([]);
+      }
+    });
+  });
+}
+
+function probeCli(bin) {
+  return new Promise((resolve) => {
+    const name = text(bin);
+    if (!name || !/^[A-Za-z0-9._\\/:?-]+$/.test(name)) {
+      resolve({ found: false, path: null });
+      return;
+    }
+    const tool = process.platform === WINDOWS ? 'where.exe' : 'which';
+    execFile(tool, [name], {
+      timeout: 3000,
+      windowsHide: true,
+      maxBuffer: 16 * 1024
+    }, (error, stdout) => {
+      if (error) {
+        resolve({ found: false, path: null });
+        return;
+      }
+      const first = String(stdout || '').split(/\r?\n/).map((line) => line.trim()).find(Boolean) || null;
+      resolve({ found: Boolean(first), path: first });
+    });
+  });
+}
+
+async function detectEntry(entry, options = {}) {
+  const platform = options.platform || process.platform;
+  const fileSystem = options.fs || fs;
+  const env = options.env || process.env;
+  const homeDir = options.homeDir || os.homedir();
+  const knownPaths = platform === WINDOWS && typeof entry.windowsPaths === 'function'
+    ? entry.windowsPaths(env, homeDir)
+    : [];
+
+  for (const candidate of knownPaths) {
+    if (exists(fileSystem, candidate)) {
+      return { found: true, path: candidate, evidence: 'known-path' };
+    }
+  }
+
+  let runningProcesses = options.runningProcesses;
+  if (runningProcesses === undefined && knownPaths.length) runningProcesses = await readRunningProcesses();
+  const running = matchingProcess(entry, runningProcesses);
+  if (running) return { found: true, path: null, evidence: 'running', process: running };
+
+  const nativeApps = options.nativeApps || options.installedApps || [];
+  const app = matchingNativeApp(entry, nativeApps);
+  if (app) return { found: true, path: null, evidence: 'native-app', app };
+
+  const probe = options.probe || probeCli;
+  const result = await probe(entry.command);
+  if (result && result.found) return { found: true, path: result.path, evidence: 'path' };
+  return { found: false, path: null, evidence: null };
+}
+
+async function discoverProviders(options = {}) {
+  const results = [];
+  for (const entry of PROVIDER_CATALOG) {
+    const detected = await detectEntry(entry, options);
+    if (!detected.found) continue;
+    results.push({
+      id: entry.id,
+      name: entry.name,
+      provider: entry.provider,
+      command: entry.command,
+      activityProcess: entry.activityProcess,
+      icon: resolveIcon('auto', entry.id),
+      path: detected.path,
+      evidence: detected.evidence,
+      process: detected.process || null,
+      app: detected.app || null
+    });
+  }
+  return results;
+}
+
+async function suggestCustomClis(config, options = {}) {
+  const custom = Array.isArray(config?.customAgents) ? config.customAgents : [];
+  const taken = new Set(custom.flatMap((agent) => [
+    text(agent.id).toLowerCase(),
+    text(agent.activityProcess).toLowerCase(),
+    text(agent.command).toLowerCase(),
+    text(agent.name).toLowerCase()
+  ]).filter(Boolean));
+  const discovered = await discoverProviders(options);
+  return discovered.filter((item) => ![
+    item.id,
+    `custom_${item.id}`,
+    item.name,
+    item.command,
+    item.activityProcess
+  ].some((value) => taken.has(text(value).toLowerCase())));
+}
+
+module.exports = {
+  DEFAULT_ICON,
+  PROVIDER_CATALOG,
+  buildProvider,
+  canonicalActivityProcess,
+  discoverProviders,
+  findCatalogEntry,
+  iconForProvider,
+  listProviders,
+  probeCli,
+  registerProvider,
+  removeProvider,
+  resolveIcon,
+  suggestCustomClis,
+  zcodeWindowsPaths,
+  _test: {
+    detectEntry,
+    matchingNativeApp,
+    matchingProcess,
+    normalizedKey,
+    readRunningProcesses
+  }
+};

--- a/electron/scrapers.js
+++ b/electron/scrapers.js
@@ -6,6 +6,7 @@ const { URL } = require('url');
 const { exec, execFile } = require('child_process');
 const { DEFAULT_CONFIG, getLocalConfig, saveLocalConfig } = require('./config');
 const { sortModelsByOrder } = require('./model-order');
+const providerRegistry = require('./provider-registry');
 
 const homeDir = os.homedir();
 
@@ -1298,60 +1299,6 @@ async function getCustomUsage(agent) {
   });
 }
 
-const SUGGEST_CLIS = [
-  { name: 'Aider', command: 'aider', icon: 'spark' },
-  { name: 'GitHub Copilot', command: 'copilot', icon: 'codex' },
-  { name: 'Amp', command: 'amp', icon: 'spark' },
-  { name: 'Goose', command: 'goose', icon: 'spark' },
-  { name: 'Crush', command: 'crush', icon: 'spark' },
-  { name: 'Qwen', command: 'qwen', icon: 'spark' }
-];
-
-function probeCli(bin) {
-  return new Promise((resolve) => {
-    const name = String(bin || '').trim();
-    if (!name || !/^[A-Za-z0-9._\\/:-]+$/.test(name)) {
-      resolve({ found: false, path: null });
-      return;
-    }
-    const tool = process.platform === 'win32' ? 'where.exe' : 'which';
-    execFile(
-      tool,
-      process.platform === 'win32' ? [name] : [name],
-      { timeout: 3000, windowsHide: true, maxBuffer: 16 * 1024 },
-      (err, stdout) => {
-        if (err) {
-          resolve({ found: false, path: null });
-          return;
-        }
-        const first = String(stdout)
-          .split(/\r?\n/)
-          .map((line) => line.trim())
-          .find(Boolean) || null;
-        resolve({ found: Boolean(first), path: first });
-      }
-    );
-  });
-}
-
-async function suggestCustomClis(config) {
-  const custom = Array.isArray(config?.customAgents) ? config.customAgents : [];
-  const taken = new Set(
-    custom
-      .map((agent) => String(agent.activityProcess || agent.command || agent.name || '').trim().toLowerCase())
-      .filter(Boolean)
-  );
-  const results = [];
-  for (const item of SUGGEST_CLIS) {
-    if (taken.has(item.command.toLowerCase()) || taken.has(item.name.toLowerCase())) continue;
-    const probe = await probeCli(item.command);
-    if (probe.found) {
-      results.push({ ...item, path: probe.path });
-    }
-  }
-  return results;
-}
-
 const BUILTIN_READERS = [
   { id: 'codex', name: 'Codex', provider: 'OpenAI', read: getCodexUsage },
   { id: 'claude', name: 'Claude Code', provider: 'Anthropic', read: getClaudeUsage },
@@ -1443,8 +1390,8 @@ module.exports = {
   getAllInstalledAgentUsage,
   getLocalConfig,
   saveLocalConfig,
-  probeCli,
-  suggestCustomClis,
+  probeCli: providerRegistry.probeCli,
+  suggestCustomClis: providerRegistry.suggestCustomClis,
   _test: {
     attachRing,
     coercePercent,

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -121,7 +121,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
     const name = draft.name.trim();
     if (!name || (draft.quotaSource === 'command' && !draft.command.trim())) return;
     addAgent({
-      id: `custom_${Date.now().toString(36)}`,
+      id: item.id ? `custom_${item.id}` : `custom_${Date.now().toString(36)}`,
       name,
       modelName: '',
       provider: 'Custom',
@@ -142,12 +142,12 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
       id: `custom_${Date.now().toString(36)}`,
       name: item.name,
       modelName: '',
-      provider: 'Custom',
+      provider: item.provider || 'Custom',
       icon: item.icon || 'spark',
       quotaSource: 'unknown',
       sessionUsedPercent: null,
       weeklyUsedPercent: null,
-      activityProcess: item.command,
+      activityProcess: item.activityProcess || item.command,
       command: ''
     });
   };
@@ -222,12 +222,12 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
         {suggestions.length > 0 && (
           <div className="mt-1">
             <span className="text-[11px] font-mono text-neutral-400 uppercase tracking-wider">
-              Found on PATH — click to add
+              Found apps / CLIs — click to add
             </span>
             <div className="mt-1.5 flex flex-wrap gap-1.5">
               {suggestions.map((item) => (
                 <button
-                  key={item.command}
+                  key={item.id || item.command}
                   onClick={() => addFromSuggestion(item)}
                   title={item.path || item.command}
                   className="px-2 py-1 rounded-lg border border-white/10 bg-white/[0.04] text-[11px] text-neutral-200 hover:border-emerald-500/40 hover:text-white"
@@ -237,7 +237,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
               ))}
             </div>
             <p className="mt-1 text-[10px] text-neutral-500 leading-snug">
-              Dash until a quota command exists. No fake live %.
+              Dash until a quota command exists. No fake live %. Unknown terminals are never registered silently.
             </p>
           </div>
         )}

--- a/tests/provider-registry.test.js
+++ b/tests/provider-registry.test.js
@@ -1,0 +1,177 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const config = require('../electron/config');
+const registry = require('../electron/provider-registry');
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agent-notch-provider-'));
+}
+
+function withConfigDir(callback) {
+  const root = tempDir();
+  const previous = {
+    dir: process.env.NOTCH_CONFIG_DIR,
+    legacy: process.env.NOTCH_LEGACY_CONFIG_PATH
+  };
+  process.env.NOTCH_CONFIG_DIR = root;
+  process.env.NOTCH_LEGACY_CONFIG_PATH = path.join(root, 'missing-legacy.json');
+  try {
+    return callback(root);
+  } finally {
+    if (previous.dir === undefined) delete process.env.NOTCH_CONFIG_DIR;
+    else process.env.NOTCH_CONFIG_DIR = previous.dir;
+    if (previous.legacy === undefined) delete process.env.NOTCH_LEGACY_CONFIG_PATH;
+    else process.env.NOTCH_LEGACY_CONFIG_PATH = previous.legacy;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function runCli(root, args) {
+  return spawnSync(process.execPath, [path.join(__dirname, '..', 'bin', 'cli.js'), ...args], {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NOTCH_CONFIG_DIR: root,
+      NOTCH_LEGACY_CONFIG_PATH: path.join(root, 'missing-legacy.json')
+    }
+  });
+}
+
+test('provider CLI registers, lists, and removes without losing unrelated config', () => {
+  withConfigDir((root) => {
+    config.saveLocalConfig({
+      alertThreshold: 71,
+      reduceMotion: true,
+      enabledModels: { codex: false, grok: true },
+      customAgents: [{ id: 'custom_existing', name: 'Existing', activityProcess: 'existing-agent' }],
+      modelOrder: ['custom_existing']
+    });
+
+    const add = runCli(root, [
+      'provider', 'add', 'zcode', '--name', 'ZCode', '--process', 'ZCode.exe',
+      '--quota', 'none', '--icon', 'auto', '--json'
+    ]);
+    assert.equal(add.status, 0, add.stderr);
+    const added = JSON.parse(add.stdout);
+    assert.equal(added.agent.id, 'custom_zcode');
+    assert.equal(added.agent.icon, 'cursor');
+    assert.equal(added.agent.quotaSource, 'unknown');
+    assert.equal(added.agent.activityProcess, 'ZCode.exe');
+
+    const disk = JSON.parse(fs.readFileSync(path.join(root, 'config.json'), 'utf8'));
+    assert.equal(disk.alertThreshold, 71);
+    assert.equal(disk.reduceMotion, true);
+    assert.equal(disk.enabledModels.codex, false);
+    assert.equal(disk.customAgents.some((agent) => agent.id === 'custom_existing'), true);
+    assert.equal(fs.readdirSync(root).some((name) => name.endsWith('.tmp')), false);
+
+    const list = runCli(root, ['provider', 'list', '--json']);
+    assert.equal(list.status, 0, list.stderr);
+    assert.deepEqual(JSON.parse(list.stdout).map((agent) => agent.id), ['custom_existing', 'custom_zcode']);
+
+    const remove = runCli(root, ['provider', 'remove', 'custom_zcode', '--json']);
+    assert.equal(remove.status, 0, remove.stderr);
+    assert.equal(JSON.parse(remove.stdout).id, 'custom_zcode');
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(root, 'config.json'), 'utf8')).customAgents.map((agent) => agent.id), ['custom_existing']);
+  });
+});
+
+test('provider register alias supports manual quota and is idempotent', () => {
+  withConfigDir((root) => {
+    const first = runCli(root, [
+      'provider', 'register', '--name', 'Local Agent', '--process', 'local-agent.exe',
+      '--quota', 'manual', '--session', '12', '--weekly', '40', '--icon', 'auto', '--json'
+    ]);
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(JSON.parse(first.stdout).agent.id, 'custom_local_agent');
+
+    const second = runCli(root, [
+      'provider', 'register', '--name', 'Local Agent', '--process', 'local-agent.exe',
+      '--quota', 'manual', '--session', '20', '--weekly', '40', '--icon', 'auto', '--json'
+    ]);
+    assert.equal(second.status, 0, second.stderr);
+    const result = JSON.parse(second.stdout);
+    assert.equal(result.created, false);
+    assert.equal(result.config.customAgents.length, 1);
+    assert.equal(result.agent.sessionUsedPercent, 20);
+  });
+});
+
+test('provider registration rejects generic runtimes and unsafe quota modes', () => {
+  withConfigDir((root) => {
+    const generic = runCli(root, ['provider', 'add', 'bad', '--name', 'Bad', '--process', 'node']);
+    assert.notEqual(generic.status, 0);
+    assert.match(generic.stderr, /generic runtime|native executable/i);
+
+    const commandWithoutSource = runCli(root, [
+      'provider', 'add', 'bad-command', '--name', 'Bad Command', '--process', 'bad-agent.exe', '--quota', 'command'
+    ]);
+    assert.notEqual(commandWithoutSource.status, 0);
+    assert.match(commandWithoutSource.stderr, /Quota command is required/i);
+    assert.equal(fs.existsSync(path.join(root, 'config.json')), false);
+  });
+});
+
+test('known-app discovery finds ZCode from a cataloged Windows install path without PATH', async () => {
+  const homeDir = path.join(os.tmpdir(), 'provider-home');
+  const env = { LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local') };
+  const expectedPath = registry.zcodeWindowsPaths(env, homeDir)[0];
+  const suggestions = await registry.discoverProviders({
+    platform: 'win32',
+    env,
+    homeDir,
+    fs: { existsSync: (candidate) => candidate === expectedPath },
+    runningProcesses: [],
+    nativeApps: [],
+    probe: async () => ({ found: false, path: null })
+  });
+  const zcode = suggestions.find((item) => item.id === 'zcode');
+  assert.ok(zcode);
+  assert.equal(zcode.path, expectedPath);
+  assert.equal(zcode.evidence, 'known-path');
+  assert.equal(zcode.activityProcess, 'ZCode.exe');
+  assert.equal(zcode.icon, 'cursor');
+});
+
+test('provider discover CLI emits suggestion JSON without changing config', () => {
+  withConfigDir((root) => {
+    const result = runCli(root, ['provider', 'discover', '--json']);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(Array.isArray(JSON.parse(result.stdout)), true);
+    assert.equal(fs.existsSync(path.join(root, 'config.json')), false);
+  });
+});
+
+test('known-app discovery can use injected native process/app evidence and never writes config', async () => {
+  const options = {
+    platform: 'win32',
+    env: { LOCALAPPDATA: path.join(os.tmpdir(), 'not-installed') },
+    homeDir: os.tmpdir(),
+    fs: { existsSync: () => false },
+    runningProcesses: ['ZCode'],
+    nativeApps: [{ appId: 'dev.zcode.app' }],
+    probe: async () => ({ found: false, path: null })
+  };
+  const suggestions = await registry.discoverProviders(options);
+  const zcode = suggestions.find((item) => item.id === 'zcode');
+  assert.ok(zcode);
+  assert.equal(zcode.evidence, 'running');
+  assert.equal(zcode.path, null);
+  assert.deepEqual(await registry.suggestCustomClis({
+    customAgents: [{ id: 'custom_zcode', name: 'Renamed', activityProcess: 'renamed.exe' }]
+  }, options), []);
+});
+
+test('icon auto maps known providers and falls back safely for unknown ones', () => {
+  assert.equal(registry.resolveIcon('auto', 'zcode'), 'cursor');
+  assert.equal(registry.resolveIcon('auto', 'claude-code'), 'claude');
+  assert.equal(registry.resolveIcon('auto', 'brand-new-agent'), 'spark');
+  assert.equal(registry.resolveIcon('spark', 'zcode'), 'spark');
+  assert.throws(() => registry.resolveIcon('not-a-bundled-icon', 'zcode'), /Unknown icon/);
+});

--- a/tests/provider-registry.test.js
+++ b/tests/provider-registry.test.js
@@ -38,7 +38,8 @@ function runCli(root, args) {
     env: {
       ...process.env,
       NOTCH_CONFIG_DIR: root,
-      NOTCH_LEGACY_CONFIG_PATH: path.join(root, 'missing-legacy.json')
+      NOTCH_LEGACY_CONFIG_PATH: path.join(root, 'missing-legacy.json'),
+      ELECTRON_OVERRIDE_DIST_PATH: path.join(root, 'missing-electron')
     }
   });
 }


### PR DESCRIPTION
## Summary
- add official 
otch provider add/register/list/remove/discover commands backed by atomic validated config writes
- share a provider catalog between CLI and Settings suggestions
- detect ZCode from its Windows install/process evidence even when it is not on PATH
- resolve --icon auto from the known catalog with a safe Spark fallback
- keep discovery opt-in: no unknown terminal process is silently registered

## Verification
- 75/75 tests (
pm test)
- 
pm run smoke:logic`n- 
pm run build`n- 
pm run pack:check`n- live 
otch provider discover --json detects the installed ZCode path without changing config