### PR TITLE
chore: prepare v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to Agent Notch are documented here.
 
-## [Unreleased]
+## [1.3.0] - 2026-09-01
+
+### Added
+
+- Provider self-registration through `notch provider add` / `register`, plus `list`, `remove`, and detection-only `discover` commands backed by validated atomic config writes.
+- Shared known-app discovery for Settings and the CLI, including ZCode detection outside `PATH` and catalog-based `--icon auto` selection with a generic Spark fallback.
 
 ### Changed
 
@@ -10,6 +15,10 @@ All notable changes to Agent Notch are documented here.
 - Quota-cross alerts while the HUD is visible are an in-rail glass toast; Windows toasts remain only when the window is hidden.
 - Codex uses the official OpenAI logomark at the same size as the other rings.
 - Hover cards wait a beat before swapping, drag lifts the ring, and the rail no longer shifts padding on hover.
+
+### Fixed
+
+- The tucked jewel now follows each ring's configured critical threshold instead of assuming the default 80% threshold.
 
 ## [1.2.1] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Agent Notch detects and tracks live usage for major coding agent ecosystems dire
 | **Cursor** | Monthly Period Usage | Cursor IDE local state (`state.vscdb` / session token) |
 | **Grok CLI** | Included quota when exposed | Grok CLI local configuration & billing endpoint; signed-in unavailable usage stays explicit |
 | **OpenCode Go** | Go Subscription Usage | OpenCode Go plan quota (excludes BYOK local engines) |
-| **Custom CLIs** | Dynamic / Custom | Automatic PATH detection; JSON stdout reader or manual snapshot |
+| **Custom CLIs** | Dynamic / Custom | Known-app suggestions or explicit `notch provider register`; JSON stdout reader or manual snapshot |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,11 @@ const RING_LIST_MAX_H = VISIBLE_RINGS * 54 + (VISIBLE_RINGS - 1) * 12;
 
 function jewelTone(model) {
   if (!model || model.quotaState !== 'known' || model.ringPercent == null) return '#34d399';
-  if (model.status === 'critical' || Number(model.ringPercent) >= 80) return '#ef4444';
+  const rawThreshold = Number(model.alertThreshold);
+  const criticalThreshold = Number.isFinite(rawThreshold)
+    ? Math.max(50, Math.min(100, rawThreshold))
+    : 80;
+  if (model.status === 'critical' || Number(model.ringPercent) >= criticalThreshold) return '#ef4444';
   if (model.status === 'warning' || Number(model.ringPercent) >= 50) return '#f59e0b';
   return '#10b981';
 }


### PR DESCRIPTION
## Summary
- bump Agent Notch to v1.3.0 after provider self-registration and the visual HUD polish
- document provider registration/discovery and the tucked jewel + in-HUD toast behavior
- keep the tucked jewel color aligned with the configured critical threshold

## Verification
- 
pm run check (75/75 tests, logic smoke, production build)
- 
pm run pack:check`n- rendered 360x620 QA of collapsed jewel, alert toast, reveal flow, expanded rail, and hover card