### PR TITLE
docs: highlight the provider discovery catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Agent Notch are documented here.
 ### Added
 
 - Provider self-registration through `notch provider add` / `register`, plus `list`, `remove`, and detection-only `discover` commands backed by validated atomic config writes.
-- Shared known-app discovery for Settings and the CLI, including ZCode detection outside `PATH` and catalog-based `--icon auto` selection with a generic Spark fallback.
+- Shared discovery for Aider, GitHub Copilot, Amp, Goose, Crush, Qwen, and ZCode across Settings and the CLI; PATH-based tools use executable lookup, ZCode can also be found from its Windows install path, and `--icon auto` uses catalog mappings with a generic Spark fallback.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -185,13 +185,14 @@ notch provider discover --json
 ```
 
 `discover` and the Settings suggestions are detection-only: they never add a
-provider silently. Known desktop apps such as ZCode can be suggested from a
-cataloged Windows install path or native process even when they are not on PATH;
-click the suggestion in Settings or run `provider add` to opt in. Unknown tools
-must be registered once by the agent/user with the command above. `--icon auto`
-selects a deliberate bundled icon for known providers (ZCode uses the Cursor
-icon) and falls back to the generic Spark icon for unknown providers; Notch does
-not extract arbitrary executable icons.
+provider silently. The catalog currently recognizes **Aider, GitHub Copilot,
+Amp, Goose, Crush, Qwen, and ZCode**. CLI tools are detected from `PATH`; ZCode
+can also be suggested from its cataloged Windows install path or native process
+when it is not on `PATH`. Click the suggestion in Settings or run `provider add`
+to opt in. Unknown tools must be registered once by the agent/user with the
+command above. `--icon auto` selects a deliberate bundled icon for known
+providers (ZCode uses the Cursor icon) and falls back to the generic Spark icon
+for unknown providers; Notch does not extract arbitrary executable icons.
 
 ---
 


### PR DESCRIPTION
Summary:
- Name the full current discovery catalog instead of presenting v1.3.0 as ZCode-only.
- Distinguish PATH discovery for CLI tools from ZCode's additional Windows install-path/process detection.
- Keep icon auto-selection and explicit opt-in behavior clear.

Verification:
- Catalog names cross-checked against the shared provider catalog.
- git diff --check.