### PR TITLE
fix: keep the working-agent pulse inside its own ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [1.3.4] - 2026-09-02
+
+### Fixed
+
+- The working-agent pulse no longer bleeds onto neighbouring icons. It was a filled,
+  blurred disc that grew to `scale(1.22)` -- roughly 85px of glow against a 65px gap
+  between rows -- so an agent at work lit up the icons above and below it and washed
+  out its own percentage label. It is now a halo that hugs the ring, and the pulse
+  animates opacity only.
+
 ## [1.3.3] - 2026-09-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -3166,7 +3166,7 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
       "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {

--- a/src/components/CircularProgressRing.jsx
+++ b/src/components/CircularProgressRing.jsx
@@ -30,31 +30,22 @@ function CircularProgressRingInner({
   const idleBloom = known
     ? `drop-shadow(0 0 2px ${ringColor}aa) drop-shadow(0 0 6px ${ringColor}40)`
     : 'none';
-  const liveBloom = `drop-shadow(0 0 5px ${ringColor}) drop-shadow(0 0 14px ${ringColor})`;
+  const liveBloom = `drop-shadow(0 0 3px ${ringColor}) drop-shadow(0 0 7px ${ringColor}cc)`;
 
   return (
     <div className="relative flex items-center justify-center cursor-pointer group">
+      {/* A halo that hugs the ring rather than a blurred disc behind it. Rows sit
+          65px apart, so a filled bloom that grew past ~26px from the centre spilled
+          onto the neighbouring icons and washed out this ring's own percentage. */}
       {isLive && (
-        <>
-          <div
-            className={`absolute -inset-2 rounded-full pointer-events-none ${reduceMotion ? '' : 'notch-live-halo'}`}
-            style={{
-              background: ringColor,
-              opacity: reduceMotion ? 0.4 : undefined,
-              filter: 'blur(8px)',
-              animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
-            }}
-          />
-          <div
-            className={`absolute inset-0 rounded-full pointer-events-none ${reduceMotion ? '' : 'notch-live-core'}`}
-            style={{
-              background: ringColor,
-              opacity: reduceMotion ? 0.28 : undefined,
-              filter: 'blur(4px)',
-              animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
-            }}
-          />
-        </>
+        <div
+          className={`absolute inset-0 rounded-full pointer-events-none ${reduceMotion ? '' : 'notch-live-halo'}`}
+          style={{
+            boxShadow: `0 0 6px 1px ${ringColor}, inset 0 0 5px ${ringColor}`,
+            opacity: reduceMotion ? 0.5 : undefined,
+            animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
+          }}
+        />
       )}
       <svg
         width={size}

--- a/src/index.css
+++ b/src/index.css
@@ -17,22 +17,15 @@ body {
   -webkit-user-drag: none;
 }
 
+/* Opacity only. The old scale(1.22) grew the halo past the 12px gap between
+   rows, so a working agent lit up its neighbours as well as itself. */
 @keyframes notch-live-breathe {
-  0%, 100% { opacity: 0.45; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.22); }
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
 }
 
 .notch-live-halo {
   animation: notch-live-breathe 1.35s ease-in-out infinite;
-}
-
-@keyframes notch-live-core {
-  0%, 100% { opacity: 0.35; }
-  50% { opacity: 0.8; }
-}
-
-.notch-live-core {
-  animation: notch-live-core 1.35s ease-in-out infinite;
 }
 
 .notch-toast {


### PR DESCRIPTION
The glow that marks a working agent read as an awkward blob and spilled onto the icons next to it.

## Why it bled

Three glows were stacking on one 38px ring:

1. an outer disc at `-inset-2`, `background: ringColor`, `blur(8px)`, grown to `scale(1.22)` by the breathe animation
2. an inner disc at `inset-0`, `blur(4px)`
3. a `drop-shadow(0 0 5px) drop-shadow(0 0 14px)` on the ring's own stroke

The outer disc alone reached about **85px** of visible glow. Rows sit **65px** apart (38px ring + 2px gap + 13px label + 12px row gap), so reaching the neighbouring icon wasn't an edge case — it was arithmetic. Being a *filled* disc rather than a halo is also why it read as a blob, and it washed out the active ring's own percentage label.

## The fix

One halo that hugs the ring — a `box-shadow` on an `inset-0` circle — and the pulse animates opacity only, so brightness changes without the footprint changing. The stroke bloom drops from 5/14px to 3/7px to match.

## Verification

Real HUD captures via `NOTCH_CAPTURE` with a live ring, not a mock: the glow stays inside its row, the rings above and below stay dark, and the label under the active ring is legible.

`npm test`: 86/86 passing.

https://claude.ai/code/session_01BJEH8BGe2q2R25JbAPEmgs