### PR TITLE
fix: make the working-agent pulse visible again, on the icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [1.3.5] - 2026-09-02
+
+### Fixed
+
+- The working-agent pulse is visible again, and now the icon itself glows with it.
+  Containing the glow in 1.3.4 left only a faint outer ring: the halo's inner glow was
+  drawn under the opaque icon hub, so it never showed. The pulse now lives inside the
+  hub, where it can be bright without reaching the next row.
+
 ## [1.3.4] - 2026-09-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -3166,7 +3166,7 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
       "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {

--- a/src/components/CircularProgressRing.jsx
+++ b/src/components/CircularProgressRing.jsx
@@ -41,7 +41,7 @@ function CircularProgressRingInner({
         <div
           className={`absolute inset-0 rounded-full pointer-events-none ${reduceMotion ? '' : 'notch-live-halo'}`}
           style={{
-            boxShadow: `0 0 6px 1px ${ringColor}, inset 0 0 5px ${ringColor}`,
+            boxShadow: `0 0 7px 1px ${ringColor}`,
             opacity: reduceMotion ? 0.5 : undefined,
             animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
           }}
@@ -77,8 +77,26 @@ function CircularProgressRingInner({
         />
       </svg>
 
-      <div className={`absolute inset-[4px] z-[2] rounded-full bg-[#18181b] flex items-center justify-center transition-colors duration-200 ${isActive ? 'ring-1 ring-white/30' : 'group-hover:bg-[#27272a]'}`}>
-        <div className="w-4 h-4 flex items-center justify-center leading-none scale-90" style={{ color: ringColor }}>
+      <div className={`absolute inset-[4px] z-[2] rounded-full bg-[#18181b] flex items-center justify-center overflow-hidden transition-colors duration-200 ${isActive ? 'ring-1 ring-white/30' : 'group-hover:bg-[#27272a]'}`}>
+        {/* The pulse the user actually watches. It lives inside the hub, so it can
+            be bright without reaching the next row -- the hub is only 30px wide. */}
+        {isLive && (
+          <div
+            className={`absolute inset-0 pointer-events-none ${reduceMotion ? '' : 'notch-live-halo'}`}
+            style={{
+              background: `radial-gradient(circle, ${ringColor}80 0%, ${ringColor}26 55%, transparent 75%)`,
+              opacity: reduceMotion ? 0.55 : undefined,
+              animationDelay: reduceMotion ? undefined : `${liveDelayMs}ms`
+            }}
+          />
+        )}
+        <div
+          className="relative z-[1] w-4 h-4 flex items-center justify-center leading-none scale-90"
+          style={{
+            color: ringColor,
+            filter: isLive ? `drop-shadow(0 0 3px ${ringColor}) drop-shadow(0 0 6px ${ringColor}99)` : undefined
+          }}
+        >
           {children}
         </div>
       </div>


### PR DESCRIPTION
Containing the glow in 1.3.4 overshot — the pulse became almost invisible. This restores it, and puts it where it reads best: on the icon.

## Why it disappeared

Two things:

1. The halo carried most of its brightness in an `inset` box-shadow — but the icon hub is an **opaque circle at `z-[2]` covering exactly that area**, so the inner glow was painted underneath it and never showed.
2. What was left was a 6px outer ring, too faint to read as a pulse.

## The fix

The pulse now sits **inside the hub**: a radial gradient behind the icon, plus a drop-shadow on the icon itself in the ring colour. That is the part a person actually watches, and it structurally cannot bleed — the hub is 30px wide inside a 38px ring, so even a bright pulse stays well short of the neighbouring row. The outer halo stays as a thin 7px hug on the ring.

## Verification

Real HUD captures (`NOTCH_CAPTURE`) sampled across one 1.35s animation cycle, as a filmstrip: the glow visibly rises and falls, the icon glows with it, the percentage label stays legible, and the rings above and below stay dark.

`npm test`: 86/86 passing.

https://claude.ai/code/session_01BJEH8BGe2q2R25JbAPEmgs