### PR TITLE
fix: keep the working-agent glow off the collapse chevron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [1.3.6] - 2026-09-02
+
+### Fixed
+
+- The working-agent glow no longer washes over the collapse chevron. The chevron sat
+  6px from the ring's edge while the glow reaches about 8px, so an active ring tinted
+  it. The gutter is now 12px, and the tucked rail's offset moves with it so the
+  collapsed strip stays exactly as wide as before.
+
 ## [1.3.5] - 2026-09-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -3166,7 +3166,7 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.5",
+      "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
       "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -319,9 +319,9 @@ export default function App() {
 
       {/* Side Notch Dock Body with Smooth Scrolling & Settings Gear */}
       <div
-        className={`group/rail relative bg-[#09090b]/98 backdrop-blur-2xl border-l-2 border-t-2 border-b-2 py-3 pl-1 pr-2 rounded-l-[26px] z-40 overflow-hidden flex flex-row items-center gap-0.5 transition-[transform,border-color,opacity,box-shadow] ease-[cubic-bezier(0.16,1,0.3,1)] ${
+        className={`group/rail relative bg-[#09090b]/98 backdrop-blur-2xl border-l-2 border-t-2 border-b-2 py-3 pl-1 pr-2 rounded-l-[26px] z-40 overflow-hidden flex flex-row items-center gap-2 transition-[transform,border-color,opacity,box-shadow] ease-[cubic-bezier(0.16,1,0.3,1)] ${
           isCollapsed
-            ? 'translate-x-[50px] opacity-100'
+            ? 'translate-x-[56px] opacity-100'
             : 'translate-x-0 border-[#27272a] hover:border-[#34d399]/35 opacity-100 shadow-2xl shadow-black/95'
         }`}
         style={{


### PR DESCRIPTION
An active ring's glow washed over the collapse chevron.

## The geometry

The rail lays out as `pl-1 (4px) | chevron (16px) | gap-0.5 (2px) | ring column (min-w-46) | pr-2 (8px)`, and the column centres its 38px ring in 46px — 4px either side.

So the chevron sat **6px** from the ring's edge (4px column padding + 2px gap), while the live glow reaches about **8px**. Not an edge case, just arithmetic.

## The fix

The gutter goes to `gap-2` (8px), giving **12px** of clearance.

That widens the rail, which matters: the collapsed state uses a fixed `translate-x-[50px]`, so a wider rail would push 6px more of itself into view when tucked. The offset moves to 56px to match — rail grows 78px → 84px, tucked strip stays **28px**, exactly as before.

## Verification

Real HUD captures in both states: expanded, where the glow now clears the chevron's gutter, and collapsed, where the tucked jewel strip is unchanged.

Worth noting the limit of that check — the chevron is `opacity-0` until the rail is hovered, so a capture can't show it lit. The clearance was verified from the glow's leftward extent against the chevron's zone, not by photographing the chevron itself.

`npm test`: 86/86 passing.

https://claude.ai/code/session_01BJEH8BGe2q2R25JbAPEmgs