### PR TITLE
fix: stop the hover card being clipped by the window edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [1.3.7] - 2026-09-02
+
+### Fixed
+
+- The hover card is no longer clipped against the window edge. The 280px card, its
+  8px margin and the rail did not fit in a 360px window; widening the chevron gutter
+  in 1.3.6 pushed the shortfall from 6px to 12px and made it obvious. The dock is now
+  380px, leaving the card 288px to sit in.
+
 ## [1.3.6] - 2026-09-02
 
 ### Fixed

--- a/electron/main.js
+++ b/electron/main.js
@@ -39,12 +39,15 @@ function configuredProcessMappings() {
   return customProcessMappings(config?.customAgents);
 }
 
+// The hover card is 280px and sits left of the rail with an 8px margin, so the
+// dock has to be wider than card + margin + rail or the card is clipped against
+// the window edge.
 const OVERLAY = {
-  dock: { width: 360, height: 620 },
+  dock: { width: 380, height: 620 },
   settings: { width: 440, height: 640 },
   // Collapsing tucks the full-size rail into the screen edge. Keeping the
   // window footprint stable avoids a detached mini-window and visual jump.
-  collapsed: { width: 360, height: 620 }
+  collapsed: { width: 380, height: 620 }
 };
 
 function reduceMotionEnabled(cfg) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-notch",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-notch",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -3166,7 +3166,7 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.6",
+      "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
       "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-notch",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Ambient right-edge desktop HUD for live AI coding-agent quotas. Windows-first, standalone, optional MindSync glow.",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
Hovering a ring showed its usage card with the left edge cut off.

## The arithmetic

The card is `w-[280px]`, sits left of the rail behind an `mr-2` (8px), inside a root that is `justify-end` with `overflow-hidden`. So the row needs `280 + 8 + rail`.

| | rail | needed | window | clipped |
|---|---|---|---|---|
| before 1.3.6 | 78px | 366px | 360px | 6px |
| after 1.3.6 | 84px | 372px | 360px | **12px** |

So the card was always slightly clipped; widening the chevron gutter in 1.3.6 doubled it and made it visible. This is a regression from that change meeting a pre-existing shortfall.

## The fix

The dock window goes to **380px**, leaving the card 288px to sit in. `collapsed` matches, since the two are deliberately kept equal to avoid a resize jump when tucking.

Nothing moves on screen — the rail is right-aligned inside the window. Measured from real captures before and after: the rail is 114.5px wide in both, still flush to the screen edge, and the capture width goes 720px → 760px exactly as expected at 2× DPI.

`npm test`: 86/86 passing.

https://claude.ai/code/session_01BJEH8BGe2q2R25JbAPEmgs