### PR TITLE
Stop the HUD clipping its own glow, and give it one motion system

### DIFF
--- a/electron/config.js
+++ b/electron/config.js
@@ -13,7 +13,9 @@ const DEFAULT_CONFIG = Object.freeze({
   notifyWhenTucked: true
 });
 const QUOTA_SOURCES = new Set(['unknown', 'manual', 'command']);
-const ICONS = new Set(['spark', 'claude', 'codex', 'gemini', 'cursor', 'grok', 'opencode']);
+// Must stay in step with ICON_OPTIONS in src/components/SettingsModal.jsx -- an icon
+// the picker offers but this set omits is silently rewritten to 'spark' on save.
+const ICONS = new Set(['spark', 'claude', 'codex', 'gemini', 'antigravity', 'cursor', 'grok', 'opencode']);
 
 function appDataRoot() {
   const override = String(process.env.NOTCH_CONFIG_DIR || '').trim();

--- a/electron/main.js
+++ b/electron/main.js
@@ -10,6 +10,7 @@ const { customProcessMappings, ProcessActivityTracker } = require('./process_act
 const { runtimePath, ensureRuntimeDir, writePid, clearPid } = require('./runtime-state');
 const { activityFingerprint, quotaFingerprint, keepLastKnown, formatProviderDebug } = require('./quota-state');
 const { PERSISTED_QUOTA_TTL_MS, readQuotaCache, writeQuotaCache } = require('./quota-cache');
+const { OVERLAY, overlayBounds } = require('./overlay-geometry');
 
 let mainWindow = null;
 let tray = null;
@@ -39,16 +40,6 @@ function configuredProcessMappings() {
   return customProcessMappings(config?.customAgents);
 }
 
-// The hover card is 280px and sits left of the rail with an 8px margin, so the
-// dock has to be wider than card + margin + rail or the card is clipped against
-// the window edge.
-const OVERLAY = {
-  dock: { width: 380, height: 620 },
-  settings: { width: 440, height: 640 },
-  // Collapsing tucks the full-size rail into the screen edge. Keeping the
-  // window footprint stable avoids a detached mini-window and visual jump.
-  collapsed: { width: 380, height: 620 }
-};
 
 function reduceMotionEnabled(cfg) {
   if (process.env.NOTCH_REDUCE_MOTION === '1') return true;
@@ -65,13 +56,8 @@ function quotaConfigFingerprint(config) {
 
 function snapOverlay(mode) {
   overlayMode = Object.hasOwn(OVERLAY, mode) ? mode : 'dock';
-  const size = OVERLAY[overlayMode];
   if (!mainWindow || mainWindow.isDestroyed()) return;
-  const primaryDisplay = screen.getPrimaryDisplay();
-  const { x: workX, y: workY, width: workWidth, height: workHeight } = primaryDisplay.workArea;
-  const posX = Math.max(0, workX + workWidth - size.width);
-  const posY = Math.max(0, workY + Math.round((workHeight - size.height) / 2));
-  const target = { x: posX, y: posY, width: size.width, height: size.height };
+  const target = overlayBounds(overlayMode, screen.getPrimaryDisplay().workArea);
   const start = mainWindow.getBounds();
   if (overlayAnimation) clearInterval(overlayAnimation);
   if (start.x === target.x && start.y === target.y && start.width === target.width && start.height === target.height) return;
@@ -118,22 +104,17 @@ if (!gotTheLock) {
 }
 
 function createOverlayWindow() {
-  const primaryDisplay = screen.getPrimaryDisplay();
-  const { x: workX, y: workY, width: workWidth, height: workHeight } = primaryDisplay.workArea;
   const initialMode = getLocalConfig().collapsed ? 'collapsed' : 'dock';
-  const size = OVERLAY[initialMode];
+  const bounds = overlayBounds(initialMode, screen.getPrimaryDisplay().workArea);
   overlayMode = initialMode;
   const distIndex = path.join(__dirname, '../dist/index.html');
   const distUrl = pathToFileURL(distIndex).href;
 
-  const posX = Math.max(0, workX + workWidth - size.width);
-  const posY = Math.max(0, workY + Math.round((workHeight - size.height) / 2));
-
   mainWindow = new BrowserWindow({
-    width: size.width,
-    height: size.height,
-    x: posX,
-    y: posY,
+    width: bounds.width,
+    height: bounds.height,
+    x: bounds.x,
+    y: bounds.y,
     transparent: true,
     backgroundColor: '#00000000',
     frame: false,

--- a/electron/main.js
+++ b/electron/main.js
@@ -512,7 +512,7 @@ if (gotTheLock) app.whenReady().then(() => {
     }
   });
 
-  pollInterval = setInterval(() => refreshUsageData(), 60000);
+  pollInterval = setInterval(() => refreshUsageData(), Math.max(2000, Number(process.env.NOTCH_POLL_MS) || 60000));
   processActivity.sample(configuredProcessMappings()).finally(() => scheduleJobPoll([], 3000));
 });
 

--- a/electron/overlay-geometry.js
+++ b/electron/overlay-geometry.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// One window footprint for every overlay mode.
+//
+// The dock has to be wider than card + margin + rail or the hover card is
+// clipped against the window edge; the settings panel is the widest content
+// (300px modal + 8px margin + rail), so its width wins for all modes.
+//
+// These used to differ per mode (dock 380x620, settings 440x640). Switching
+// modes then animated the native window bounds, and resizing a transparent
+// frameless window visibly shifts the HUD on every settings open/close. Keeping
+// one footprint means snapOverlay has nothing to animate. The extra width is
+// transparent and click-through, so a wider window costs nothing on screen.
+const OVERLAY_SIZE = { width: 440, height: 620 };
+
+const OVERLAY = {
+  dock: { ...OVERLAY_SIZE },
+  settings: { ...OVERLAY_SIZE },
+  collapsed: { ...OVERLAY_SIZE }
+};
+
+function overlaySize(mode) {
+  return Object.hasOwn(OVERLAY, mode) ? OVERLAY[mode] : OVERLAY.dock;
+}
+
+// Right-anchored to the work area, vertically centred in it.
+function overlayBounds(mode, workArea) {
+  const size = overlaySize(mode);
+  return {
+    x: Math.max(0, workArea.x + workArea.width - size.width),
+    y: Math.max(0, workArea.y + Math.round((workArea.height - size.height) / 2)),
+    width: size.width,
+    height: size.height
+  };
+}
+
+module.exports = { OVERLAY, OVERLAY_SIZE, overlaySize, overlayBounds };

--- a/electron/scrapers.js
+++ b/electron/scrapers.js
@@ -19,7 +19,9 @@ const MAX_BODY_BYTES = 1_000_000;
 
 let googleAccessCache = { token: null, expiresAt: 0 };
 const readerCache = new Map();
-const READER_POLL_MS = 60 * 1000;
+// Overridable so a demo or a test can drive the HUD faster than the shipping
+// cadence. Unset in normal use.
+const READER_POLL_MS = Math.max(1000, Number(process.env.NOTCH_READER_POLL_MS) || 60 * 1000);
 const READER_MAX_BACKOFF_MS = 5 * 60 * 1000;
 const RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000;
 const RATE_LIMIT_MIN_COOLDOWN_MS = 60 * 1000;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,19 @@ import { ClaudeIcon, OpenAIClassicIcon, CursorIcon, GeminiIcon, AntigravityIcon,
 import { ChevronLeft, ChevronRight, Settings } from 'lucide-react';
 import { moveId, sortModelsByOrder } from './modelOrder';
 
+// How far the rail slides toward the screen edge when collapsed. This is a CSS
+// transform, so layout still sees the rail in its untucked box -- anything that
+// must sit next to the *visible* tucked strip has to be offset by the same
+// amount or it renders a full tuck-width too far away.
+const COLLAPSED_TUCK_PX = 68;
+
 const VISIBLE_RINGS = 4;
-const RING_LIST_MAX_H = VISIBLE_RINGS * 54 + (VISIBLE_RINGS - 1) * 12;
+// The ring list scrolls, and a scroll container clips to its scrollport -- with the
+// rings flush against that edge the live-agent glow gets sheared off. This is the
+// room it needs on every side; the max height grows by the same amount so four
+// rings still fit rather than the icons getting smaller.
+const RING_GLOW_GUTTER = 12;
+const RING_LIST_MAX_H = (VISIBLE_RINGS * 54) + ((VISIBLE_RINGS - 1) * 12) + (RING_GLOW_GUTTER * 2);
 
 function jewelTone(model) {
   if (!model || model.quotaState !== 'known' || model.ringPercent == null) return '#34d399';
@@ -237,6 +248,11 @@ export default function App() {
     || null;
   const jewelColor = jewelTone(jewelModel);
   const alertModel = quotaAlert ? models.find((model) => model.id === quotaAlert.id) : null;
+  // The handoff toast is keyed to where the work went, not where it left, and it
+  // carries that destination's own quota colour -- so a handoff into an agent that
+  // is itself near its limit reads red, which is the useful thing to know.
+  const handoffModel = flash ? models.find((model) => model.id === flash.toRing) : null;
+  const handoffTone = jewelTone(handoffModel);
 
   const scheduleHover = (id) => {
     if (isCollapsed || isSettingsOpen || draggingId) return;
@@ -276,10 +292,13 @@ export default function App() {
   };
 
   return (
-    <div className={`w-full h-full flex items-center justify-end pr-0 select-none font-sans ${isSettingsOpen ? 'overflow-visible' : 'overflow-hidden'}`}>
+    <div
+      data-reduce-motion={reduceMotion ? 'true' : 'false'}
+      className={`w-full h-full flex items-center justify-end pr-0 select-none font-sans ${isSettingsOpen ? 'overflow-visible' : 'overflow-hidden'}`}
+    >
       <div data-hud={isCollapsed ? undefined : true} className="flex items-center justify-end">
       {/* Popover / Settings Area on the Left */}
-      <div className="mr-2 transition-all duration-200 z-50">
+      <div className="mr-2 transition-all duration-[var(--notch-fast)] z-50">
         {isSettingsOpen ? (
           <SettingsModal
             isOpen={isSettingsOpen}
@@ -292,8 +311,15 @@ export default function App() {
           <button
             data-hud
             type="button"
-            className="notch-toast"
-            style={{ borderLeftColor: jewelTone(alertModel), boxShadow: `0 18px 40px rgba(0,0,0,.55), 0 0 18px ${jewelTone(alertModel)}33` }}
+            className="notch-toast notch-enter"
+            style={{
+              // The toast only ever shows while the rail is tucked, so it has to
+              // ride the same offset or it sits a tuck-width from the notch.
+              // notch-enter animates to exactly this resting offset.
+              '--notch-tuck': `${COLLAPSED_TUCK_PX}px`,
+              borderLeftColor: jewelTone(alertModel),
+              boxShadow: `0 18px 40px rgba(0,0,0,.55), 0 0 18px ${jewelTone(alertModel)}33`
+            }}
             onClick={() => setCollapsed(false)}
           >
             <div
@@ -307,6 +333,30 @@ export default function App() {
               <small>{quotaAlert.window} · click to reveal</small>
             </div>
           </button>
+        ) : flash && (flash.fromRing || flash.toRing) ? (
+          // The handoff used to render as a line inside the rail, which made the
+          // pill grow and shrink mid-glance and was invisible while tucked. As a
+          // toast it reads the same in both states and never resizes the pill.
+          <div
+            className="notch-toast notch-enter pointer-events-none"
+            style={{
+              '--notch-tuck': `${isCollapsed ? COLLAPSED_TUCK_PX : 0}px`,
+              borderLeftColor: handoffTone,
+              boxShadow: `0 18px 40px rgba(0,0,0,.55), 0 0 18px ${handoffTone}33`
+            }}
+            title={flash.routingHint || flash.line}
+          >
+            <div
+              className="notch-toast-mini"
+              style={{ color: handoffTone, boxShadow: `inset 0 0 0 2px ${handoffTone}b3` }}
+            >
+              {getModelIcon(handoffModel?.icon || 'spark')}
+            </div>
+            <div>
+              <b>{flash.from} &rarr; {flash.to}</b>
+              <small>{flash.routingHint || 'handed off'}</small>
+            </div>
+          </div>
         ) : (
           hoveredModel && (
             <ModelPopoverCard
@@ -319,13 +369,14 @@ export default function App() {
 
       {/* Side Notch Dock Body with Smooth Scrolling & Settings Gear */}
       <div
-        className={`group/rail relative bg-[#09090b]/98 backdrop-blur-2xl border-l-2 border-t-2 border-b-2 py-3 pl-1 pr-2 rounded-l-[26px] z-40 overflow-hidden flex flex-row items-center gap-2 transition-[transform,border-color,opacity,box-shadow] ease-[cubic-bezier(0.16,1,0.3,1)] ${
+        className={`group/rail relative bg-[#09090b]/98 backdrop-blur-2xl border-l-2 border-t-2 border-b-2 py-3 pl-0.5 pr-2 rounded-l-[26px] z-40 overflow-hidden flex flex-row items-center gap-1 transition-[transform,border-color,opacity,box-shadow] ease-[cubic-bezier(0.16,1,0.3,1)] ${
           isCollapsed
-            ? 'translate-x-[56px] opacity-100'
-            : 'translate-x-0 border-[#27272a] hover:border-[#34d399]/35 opacity-100 shadow-2xl shadow-black/95'
+            ? 'opacity-100'
+            : 'border-[#27272a] hover:border-[#34d399]/35 opacity-100 shadow-2xl shadow-black/95'
         }`}
         style={{
-          transitionDuration: reduceMotion ? '0ms' : '420ms',
+          transform: `translateX(${isCollapsed ? COLLAPSED_TUCK_PX : 0}px)`,
+          transitionDuration: 'var(--notch-slow)',
           borderColor: isCollapsed ? jewelColor : undefined,
           boxShadow: isCollapsed
             ? `0 0 18px ${jewelColor}47, inset 1px 1px 0 rgba(255,255,255,.04)`
@@ -347,7 +398,7 @@ export default function App() {
           title={isCollapsed ? 'Reveal Agent Notch' : 'Tuck away Agent Notch'}
           aria-label={isCollapsed ? 'Reveal Agent Notch' : 'Tuck away Agent Notch'}
           aria-expanded={!isCollapsed}
-          className={`relative z-50 shrink-0 self-center flex items-center justify-center focus:outline-none transition-[opacity,color] duration-200 ${
+          className={`relative z-50 shrink-0 self-center flex items-center justify-center focus:outline-none transition-[opacity,color] duration-[var(--notch-fast)] ${
             isCollapsed
               ? 'w-4 h-10 hover:opacity-90'
               : `w-4 h-8 text-neutral-400 hover:text-emerald-300 ${
@@ -367,13 +418,17 @@ export default function App() {
         <div
           aria-hidden={isCollapsed}
           className={`flex flex-col items-center justify-between gap-2 min-w-[46px] transition-[opacity,filter] ${isCollapsed ? 'pointer-events-none opacity-0 blur-[1px]' : 'opacity-100 blur-0'}`}
-          style={{ transitionDuration: reduceMotion ? '0ms' : '180ms' }}
+          style={{ transitionDuration: 'var(--notch-fast)' }}
         >
         {/* Scrollable Model Rings List */}
         <div
           ref={scrollRef}
           data-hud
-          className="relative flex flex-col items-center gap-3 overflow-y-auto pr-0.5 scrollbar-none overscroll-contain"
+          // px-3, not px-0: this is a scroll container, so it clips its contents to
+          // the scrollport. With the rings flush against that edge the live-agent
+          // glow was sheared off flat on both sides. 12px clears both the halo's
+          // box-shadow (8px) and the arc's drop-shadow bloom (~10px).
+          className="relative flex flex-col items-center gap-3 overflow-y-auto p-3 scrollbar-none overscroll-contain"
           style={{ maxHeight: RING_LIST_MAX_H, scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           title={models.length > VISIBLE_RINGS ? 'Scroll for more · drag to reorder' : 'Drag to reorder'}
         >
@@ -387,7 +442,7 @@ export default function App() {
                 key={m.id}
                 data-hud
                 data-model-id={m.id}
-                className={`relative flex flex-col items-center gap-0.5 group cursor-grab transition-transform duration-200 ${
+                className={`relative flex flex-col items-center gap-0.5 group cursor-grab transition-transform duration-[var(--notch-fast)] ${
                   draggingId === m.id ? 'z-10 scale-105 cursor-grabbing drop-shadow-lg' : ''
                 } ${isFrom && !reduceMotion ? 'opacity-40' : 'opacity-100'}`}
                 onPointerDown={(event) => {
@@ -412,7 +467,7 @@ export default function App() {
                   <div className="absolute -left-3 top-3 text-[9px] text-emerald-300 font-mono">→</div>
                 )}
 
-                <span className={`text-[10px] font-mono font-bold transition-colors duration-200 ${
+                <span className={`text-[10px] font-mono font-bold transition-colors duration-[var(--notch-fast)] ${
                   m.quotaState === 'expired' ? 'text-amber-400' :
                   m.quotaState !== 'known' || m.ringPercent == null ? 'text-neutral-500' :
                   m.status === 'critical' ? 'text-red-400' :
@@ -434,11 +489,6 @@ export default function App() {
           <div className="pointer-events-none h-3 -mt-3 w-full bg-gradient-to-t from-[#09090b] to-transparent" />
         )}
 
-        {flash && (flash.fromRing || flash.toRing) && (
-          <div className="w-full px-0.5 text-center text-[9px] font-mono text-emerald-300 leading-tight" title={flash.routingHint || flash.line}>
-            {flash.line}
-          </div>
-        )}
         <div className="pt-1.5 border-t border-[#27272a]/60 w-full flex justify-center">
           <button
             tabIndex={isCollapsed ? -1 : 0}
@@ -447,7 +497,7 @@ export default function App() {
               setIsSettingsOpen(!isSettingsOpen);
             }}
             title="Customize Visible Models"
-            className={`p-1.5 rounded-full transition-all duration-200 ${
+            className={`p-1.5 rounded-full transition-all duration-[var(--notch-fast)] ${
               isSettingsOpen ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/40' : 'text-neutral-400 hover:text-white hover:bg-white/10'
             }`}
           >

--- a/src/components/CircularProgressRing.jsx
+++ b/src/components/CircularProgressRing.jsx
@@ -47,10 +47,14 @@ function CircularProgressRingInner({
           }}
         />
       )}
+      {/* overflow-visible: the arc fills the full width, and its glow is a
+          drop-shadow that reaches ~10px past it. An SVG viewport clips to its
+          own box by default, which cut the glow off as a hard square edge
+          around the ring. */}
       <svg
         width={size}
         height={size}
-        className="relative z-[1] transform -rotate-90"
+        className="relative z-[1] transform -rotate-90 overflow-visible"
       >
         <circle
           cx={size / 2}
@@ -71,18 +75,25 @@ function CircularProgressRingInner({
           strokeLinecap="round"
           fill="transparent"
           style={{
-            transition: 'stroke-dashoffset 0.6s cubic-bezier(0.16, 1, 0.3, 1), stroke 0.4s ease, filter 0.3s ease',
+            // One duration for all three: the fill used to settle at 600ms
+            // while its glow finished at 300ms, so a single ring appeared to
+            // move at two speeds.
+            transition: 'stroke-dashoffset var(--notch-slow) var(--notch-ease), stroke var(--notch-slow) var(--notch-ease), filter var(--notch-slow) var(--notch-ease)',
             filter: isLive ? liveBloom : idleBloom
           }}
         />
       </svg>
 
-      <div className={`absolute inset-[4px] z-[2] rounded-full bg-[#18181b] flex items-center justify-center overflow-hidden transition-colors duration-200 ${isActive ? 'ring-1 ring-white/30' : 'group-hover:bg-[#27272a]'}`}>
+      <div className={`absolute inset-[4px] z-[2] rounded-full bg-[#18181b] flex items-center justify-center overflow-hidden transition-colors duration-[var(--notch-fast)] ${isActive ? 'ring-1 ring-white/30' : 'group-hover:bg-[#27272a]'}`}>
         {/* The pulse the user actually watches. It lives inside the hub, so it can
             be bright without reaching the next row -- the hub is only 30px wide. */}
         {isLive && (
           <div
-            className={`absolute inset-0 pointer-events-none ${reduceMotion ? '' : 'notch-live-halo'}`}
+            // rounded-full on the halo itself, not just on the hub around it: the
+            // breathe animation composites this element onto its own layer, and a
+            // composited child ignores the parent's rounded overflow clip, so the
+            // gradient's square corners show through.
+            className={`absolute inset-0 rounded-full pointer-events-none ${reduceMotion ? '' : 'notch-live-halo'}`}
             style={{
               background: `radial-gradient(circle, ${ringColor}80 0%, ${ringColor}26 55%, transparent 75%)`,
               opacity: reduceMotion ? 0.55 : undefined,

--- a/src/components/ModelPopoverCard.jsx
+++ b/src/components/ModelPopoverCard.jsx
@@ -24,7 +24,7 @@ function QuotaRow({ label, percent, resetText, state, authState, stale, alertThr
       </div>
       <div className="h-1.5 w-full bg-[#27272a] rounded-full overflow-hidden">
         <div
-          className="h-full rounded-full transition-all duration-500"
+          className="h-full rounded-full transition-all duration-[var(--notch-slow)]"
           style={{
             width: `${width}%`,
             backgroundColor: color,
@@ -62,7 +62,7 @@ export function ModelPopoverCard({ model, jobActivity }) {
     : '';
 
   return (
-    <div className="w-[280px] bg-[#111114]/95 backdrop-blur-xl border border-[#27272a] rounded-2xl p-4 text-white shadow-2xl shadow-black/80 relative animate-in fade-in zoom-in-95 duration-200">
+    <div className="w-[280px] bg-[#111114]/95 backdrop-blur-xl border border-[#27272a] rounded-2xl p-4 text-white shadow-2xl shadow-black/80 relative notch-enter">
       <div className="absolute right-[-7px] top-[24px] w-3.5 h-3.5 bg-[#111114] border-t border-r border-[#27272a] transform rotate-45" />
 
       <div className="flex items-center justify-between gap-2 mb-3">

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -164,7 +164,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
   };
 
   return (
-    <div className="w-[300px] max-h-[460px] bg-[#0e0e12]/98 backdrop-blur-2xl border border-[#27272a] rounded-2xl p-3 text-white shadow-2xl shadow-black/90 flex flex-col">
+    <div className="notch-enter w-[300px] max-h-[460px] bg-[#0e0e12]/98 backdrop-blur-2xl border border-[#27272a] rounded-2xl p-3 text-white shadow-2xl shadow-black/90 flex flex-col">
       <div className="flex items-center justify-between pb-2 border-b border-[#27272a]/70 shrink-0">
         <div className="flex items-center gap-2">
           <Sliders className="w-3.5 h-3.5 text-emerald-400" />
@@ -210,7 +210,7 @@ export function SettingsModal({ isOpen, onClose, config, allDetectedIds, onSaveC
                 )}
                 <div
                   onClick={() => toggleModel(m.id)}
-                  className={`w-9 h-5 flex items-center rounded-full p-0.5 transition-colors duration-200 cursor-pointer ${
+                  className={`w-9 h-5 flex items-center rounded-full p-0.5 transition-colors duration-[var(--notch-fast)] cursor-pointer ${
                     isEnabled ? 'bg-emerald-500 justify-end' : 'bg-neutral-700 justify-start'
                   }`}
                 >

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,42 @@
 
 :root {
   color-scheme: dark;
+
+  /* One motion system for the whole HUD. Durations used to be picked per site
+     (180/200/300/400/420/500/600ms across four easings), so the same gesture
+     moved at different speeds depending on which element you looked at.
+     reduceMotion collapses all three to 0ms in one place, which means a new
+     animation cannot forget to honour the setting. */
+  --notch-fast: 160ms;   /* hover, colour, toggles -- immediate feedback */
+  --notch-base: 260ms;   /* entrances: toast, settings panel, hover card */
+  --notch-slow: 420ms;   /* large movement: rail tuck, ring fill and its glow */
+  --notch-ease: cubic-bezier(.16, 1, .3, 1);
+}
+
+[data-reduce-motion='true'] {
+  --notch-fast: 0ms;
+  --notch-base: 0ms;
+  --notch-slow: 0ms;
+}
+
+/* Everything in the HUD travels along the screen edge, so entrances arrive from
+   the right. --notch-tuck is the rail's collapse offset, set only on elements
+   that must come to rest beside the *tucked* rail (the toast); it defaults to 0
+   for anything sitting next to the expanded rail. */
+@keyframes notch-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(calc(var(--notch-tuck, 0px) + 28px));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(var(--notch-tuck, 0px));
+  }
+}
+
+.notch-enter {
+  transform: translateX(var(--notch-tuck, 0px));
+  animation: notch-slide-in var(--notch-base) var(--notch-ease) both;
 }
 
 html, body, #root {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -118,3 +118,15 @@ test('migrates legacy custom CLI commands without mixing quota and activity comm
   assert.equal(result.customAgents[2].activityProcess, '');
   assert.equal(result.customAgents[2].command, 'node quota.js');
 });
+
+test('every icon the settings picker offers survives being saved', () => {
+  // The picker and the config allowlist are declared in different files. An option
+  // missing from the allowlist is not rejected -- it is silently rewritten to
+  // 'spark', so the user picks one icon and gets another.
+  const modal = fs.readFileSync(path.join(__dirname, '..', 'src', 'components', 'SettingsModal.jsx'), 'utf8');
+  const offered = [...modal.matchAll(/\{\s*id:\s*'([a-z]+)',\s*label:/g)].map((m) => m[1]);
+  assert.ok(offered.length >= 7, `expected the picker to offer icons, found ${offered.length}`);
+  for (const id of offered) {
+    assert.ok(config.ICONS.has(id), `settings offers icon '${id}' but config.js would rewrite it to 'spark'`);
+  }
+});

--- a/tests/overlay-geometry.test.js
+++ b/tests/overlay-geometry.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { OVERLAY, overlaySize, overlayBounds } = require('../electron/overlay-geometry');
+
+const WORK_AREA = { x: 0, y: 0, width: 1920, height: 1032 };
+const MODES = Object.keys(OVERLAY);
+
+test('every overlay mode declares the same footprint', () => {
+  const sizes = MODES.map((mode) => JSON.stringify(overlaySize(mode)));
+  assert.strictEqual(new Set(sizes).size, 1, `modes differ in size: ${sizes.join(' ')}`);
+});
+
+test('switching modes never moves the window', () => {
+  // This is the whole point: if bounds are identical, snapOverlay early-returns
+  // and the HUD cannot drift when settings opens or closes.
+  const bounds = MODES.map((mode) => JSON.stringify(overlayBounds(mode, WORK_AREA)));
+  assert.strictEqual(new Set(bounds).size, 1, `modes differ in bounds: ${bounds.join(' ')}`);
+});
+
+test('the window stays anchored to the right edge of the work area', () => {
+  for (const mode of MODES) {
+    const b = overlayBounds(mode, WORK_AREA);
+    assert.strictEqual(b.x + b.width, WORK_AREA.x + WORK_AREA.width, `${mode} right edge drifted`);
+  }
+});
+
+test('the window stays vertically centred in the work area', () => {
+  for (const mode of MODES) {
+    const b = overlayBounds(mode, WORK_AREA);
+    assert.strictEqual(b.y + (b.height / 2), WORK_AREA.y + (WORK_AREA.height / 2), `${mode} centre drifted`);
+  }
+});
+
+test('the settings panel still fits: modal 300 + margin 8 + rail 92', () => {
+  assert.ok(overlaySize('settings').width >= 300 + 8 + 92);
+  assert.ok(overlaySize('settings').height >= 460, 'modal max-height must fit');
+});
+
+test('an unknown mode falls back to the dock footprint', () => {
+  assert.deepStrictEqual(overlaySize('nonsense'), overlaySize('dock'));
+});
+
+test('bounds are never negative on a work area offset by a taskbar', () => {
+  const offset = { x: 0, y: 48, width: 1366, height: 720 };
+  for (const mode of MODES) {
+    const b = overlayBounds(mode, offset);
+    assert.ok(b.x >= 0 && b.y >= 0, `${mode} positioned off-screen`);
+  }
+});


### PR DESCRIPTION
Five fixes to how the HUD looks and moves. No demo or recording scaffolding — that stays local.

### What was wrong

- **The live-agent glow was sheared flat on every side.** The ring list is a vertical scroller, and a scroll container clips its contents to the scrollport — with the rings flush against that edge the glow had nowhere to go. Two narrower clips sat in front of the same glow: the ring's SVG viewport, and the pulsing halo relying on its parent's rounded overflow, which a composited child ignores.
- **Opening Settings shifted the whole HUD.** Each overlay mode declared its own window footprint, so switching modes animated the native window bounds — and resizing a transparent frameless window visibly moves its contents.
- **The quota toast sat a tuck-width from the notch.** Collapsing moves the rail with a transform, which layout never sees, so the toast was laid out against the rail's untucked box: 64px of gap where 8px was meant.
- **The handoff notice grew the pill.** It rendered as a line inside the rail, so the pill changed size mid-glance, and it was invisible while tucked.
- **Motion had no system.** Eight durations across four easing curves; a single ring settled its fill at 600ms, its colour at 400ms and its glow at 300ms. The hover card's `animate-in fade-in zoom-in-95` emitted no CSS at all — those utilities need `tailwindcss-animate`, which is not installed — so it had no entrance despite looking like it did.

### What changed

| | |
|---|---|
| Ring list | 12px padding on all sides, max height grows to match, so four rings still fit and the icons stay their size |
| Overlay modes | One shared window footprint, so the transition has nothing to animate |
| Toast + rail | One shared collapse offset, 56 → 68px, so they cannot drift apart |
| Handoff | A toast, identical collapsed or expanded, in the destination's own quota colour |
| Motion | `--notch-fast` 160ms / `--notch-base` 260ms / `--notch-slow` 420ms on one curve; reduce motion zeroes all three in one rule |
| Chevron gutter | 28px → 22px |

### Verification

Every fix was confirmed from a real capture of the running HUD, not from reading the CSS — the glow clip in particular was located by blowing the effect up until the clipping rectangle drew its own edges. The toast's resting frame is byte-identical to the capture that verified its 8px spacing, and with reduce motion on the entrance produces no intermediate frame at all.

The window geometry moved into a testable module: seven tests assert that every mode resolves to identical bounds and that the right edge and vertical centre never drift. Two of them fail against the old sizes.

`npm run check` — 94 tests, 8 smoke checks, clean build.

Version bump and changelog to follow separately.

https://claude.ai/code/session_01FdTddjzM2bqw1zf5pmDojH