### PR TITLE
npm badges, registry install, and tag-triggered publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish
+
+# Pushing a version tag publishes that version to npm. Bump package.json,
+# commit, tag `vX.Y.Z`, push the tag -- nothing else to remember.
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      # A tag that disagrees with package.json would publish the wrong version
+      # under the right name, and npm versions cannot be reused. Fail first.
+      - name: Tag must match package.json
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::tag $GITHUB_REF_NAME says $TAG, package.json says $PKG"
+            exit 1
+          fi
+          echo "publishing $PKG"
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run smoke:logic
+      - run: npm run build
+      - run: npm run pack:check
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Agent Notch are documented here.
 
+## [Unreleased]
+
+### Added
+
+- Published to npm as [`agent-notch`](https://www.npmjs.com/package/agent-notch).
+  Install is now `npm i -g agent-notch` rather than pulling the GitHub repo, and
+  `npx agent-notch` runs it once without installing.
+
+- A publish workflow: pushing a `vX.Y.Z` tag runs the full check suite and publishes
+  that version to npm with provenance. It refuses to run if the tag and
+  `package.json` disagree, since an npm version cannot be reused.
+
 ## [1.3.8] - 2026-09-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   <img src="https://img.shields.io/badge/Node.js-%3E%3D18.0.0-green?style=flat-square&logo=node.js" alt="Node.js">
   <a href="https://github.com/adityarya24/agent-notch/actions/workflows/ci.yml"><img src="https://github.com/adityarya24/agent-notch/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/adityarya24/agent-notch/releases/latest"><img src="https://img.shields.io/github/v/release/adityarya24/agent-notch?style=flat-square&label=release" alt="Latest release"></a>
+  <a href="https://www.npmjs.com/package/agent-notch"><img src="https://img.shields.io/npm/v/agent-notch?style=flat-square&logo=npm&color=cb3837" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/agent-notch"><img src="https://img.shields.io/npm/dm/agent-notch?style=flat-square&logo=npm&label=downloads" alt="npm downloads"></a>
   <img src="https://img.shields.io/badge/Stack-Electron%20%7C%20React%2019%20%7C%20Tailwind%20v4-61dafb?style=flat-square" alt="Stack">
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=flat-square" alt="License">
 </p>
@@ -135,7 +137,7 @@ irm https://raw.githubusercontent.com/adityarya24/agent-notch/main/install.ps1 |
 ### Option 2: Global NPM Install
 
 ```bash
-npm i -g github:adityarya24/agent-notch
+npm i -g agent-notch
 notch
 notch autostart
 ```
@@ -143,7 +145,7 @@ notch autostart
 ### Option 3: Run Once via NPX
 
 ```bash
-npx github:adityarya24/agent-notch
+npx agent-notch
 ```
 
 ### Option 4: Local Development Clone


### PR DESCRIPTION
Follow-up to the 1.3.8 release, now that [`agent-notch`](https://www.npmjs.com/package/agent-notch) is on npm.

### Install

Installing no longer pulls the GitHub repo and builds on the user's machine:

```bash
npm i -g agent-notch   # was: npm i -g github:adityarya24/agent-notch
npx agent-notch        # was: npx github:adityarya24/agent-notch
```

### Badges

npm version and monthly downloads, next to the existing release badge.

### Publishing

`.github/workflows/publish.yml` runs on a `v*` tag push: the same checks CI runs, then `npm publish --provenance --access public`.

It refuses to publish when the tag and `package.json` disagree. That guard matters more than it looks — an npm version number can never be reused, so pushing `v1.3.9` against a `package.json` still saying `1.3.8` would burn the wrong number permanently.

**Before this can work:** the repo needs an `NPM_TOKEN` secret — a granular automation token from npmjs, scoped to write this one package. Until that exists a tag push will fail at the publish step, having already run the tests.

After that the release flow is: bump `package.json` → commit → `git tag vX.Y.Z` → push the tag.

`npm run check` — 94 tests, 8 smoke checks, clean build.

https://claude.ai/code/session_01FdTddjzM2bqw1zf5pmDojH